### PR TITLE
Add rpc-support to the overarching site.yml

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,3 +1,4 @@
 ---
 - include: horizon-extensions.yml
+- include: rpc-support.yml
 - include: setup-maas.yml


### PR DESCRIPTION
site.yml acts as a "all playbook" play, adding the rpc-support playbook
to this so that all additional "rpc-extras" plays are run as part of
site.yml