### PR TITLE
Get pccommon.sh on neutron_agent & utility hosts

### DIFF
--- a/playbooks/roles/rpc_support/tasks/main.yml
+++ b/playbooks/roles/rpc_support/tasks/main.yml
@@ -44,3 +44,7 @@
 - include: holland_config.yml
   when: >
     inventory_hostname in groups['galera']
+
+- include: pccommon_get.yml
+  when: >
+    inventory_hostname in groups['utility'] or inventory_hostname in groups['neutron_agent']

--- a/playbooks/roles/rpc_support/tasks/pccommon_get.yml
+++ b/playbooks/roles/rpc_support/tasks/pccommon_get.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Download pccommon.sh
+  get_url:
+    url: "https://github.com/rsoprivatecloud/pubscripts/blob/master/pccommon.sh"
+    dest: /root/pccommon.sh
+    mode: 0700


### PR DESCRIPTION
Get the pccommon.sh script from rsoprivatecloud repository and set its
perms to be executable inside /root/ - this should be done on all
neutron_agent and utility hosts.

Fixes-Issue: #10