### PR TITLE
Create external address setting for maas checks

### DIFF
--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -23,7 +23,7 @@ maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
 maas_notification_plan: npManaged
-
+maas_external_ip_address: {{ external_vip_address }}
 
 # By default we will create an agent token for each entity, however if you'd
 # prefer to use the same agent token for all entities then specify it here

--- a/playbooks/roles/rpc_maas/tasks/remote.yml
+++ b/playbooks/roles/rpc_maas/tasks/remote.yml
@@ -25,7 +25,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_cinder_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: "{{ cinder_service_port }}"
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -46,7 +46,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_glance_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 9292
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -67,7 +67,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_keystone_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: "{{ keystone_service_port }}"
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -88,7 +88,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_neutron_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 9696
     path: "/"
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -109,7 +109,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_nova_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 8774
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -130,7 +130,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_horizon_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 443
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -151,7 +151,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_heat_api_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 8004
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -172,7 +172,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_heat_cfn_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 8000
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
@@ -193,7 +193,7 @@
     monitoring_zones: "{{ maas_monitoring_zones }}"
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_heat_cloudwatch_scheme | default(maas_scheme)}}"
-    ip_address: "{{ external_vip_address }}"
+    ip_address: "{{ maas_external_ip_address }}"
     port: 8003
     path: ""
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"


### PR DESCRIPTION
New setting maas_external_ip_address defined with default value of
external_vip_address and existing remote maas checked migrated to
use the new setting.

Fixes #27