### PR TITLE
Fix regression introduced in adcffa0

### DIFF
--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -64,7 +64,8 @@ maas_monitoring_zones:
   - mzhkg
 
 # Set the fqdn extension if required, sample only
-# maas_fqdn_extenstion: .example.com
+# maas_fqdn_extension: .example.com
+maas_fqdn_extension:
 
 # Set the following to skip creating alarms for this device for disk utilisation monitoring
 # maas_excluded_devices: ['xvde']

--- a/playbooks/roles/rpc_maas/tasks/cdm_setup.yml
+++ b/playbooks/roles/rpc_maas/tasks/cdm_setup.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
 
 - name: Validate if check exists

--- a/playbooks/roles/rpc_maas/tasks/dell_setup.yml
+++ b/playbooks/roles/rpc_maas/tasks/dell_setup.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
 
 - name: Validate if check exists

--- a/playbooks/roles/rpc_maas/tasks/filesystem_autosetup.yml
+++ b/playbooks/roles/rpc_maas/tasks/filesystem_autosetup.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
 
 - name: Validate if check exists

--- a/playbooks/roles/rpc_maas/tasks/filesystem_setup.yml
+++ b/playbooks/roles/rpc_maas/tasks/filesystem_setup.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
 
 - name: Validate if check exists

--- a/playbooks/roles/rpc_maas/tasks/local_setup.yml
+++ b/playbooks/roles/rpc_maas/tasks/local_setup.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ physical_host|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ physical_host|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
   delegate_to: "{{ physical_host }}"
 

--- a/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/playbooks/roles/rpc_maas/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - include: raxmon_agent_install.yml
   vars:
-    entity_name: "{{ inventory_hostname }}{{ maas_fqdn_extension|default('') }}"
+    entity_name: "{{ inventory_hostname }}{{ maas_fqdn_extension }}"
   when: >
     inventory_hostname in groups['hosts']
 


### PR DESCRIPTION
In commit adcffa0, we added |default('') to maas_fqdn_extension since
maas_fqdn_extension was not defaulted in any user variable files and
would cause an ansible run failure due to the variable not existing.
Upon doing this, I noticed that maas_fqdn_extension was _always_ being
set to '', even when it was defined in a user variables file.  Oddly,
I could print the contents of maas_fqdn_extension right above the
change made and it was visible, so it is unclear why adding the
|defauilt('') was causing this issue.

This change removes any |default('') reference on maas_fqdn_extension
and sets a default value in rpc_maas/defaults/main.yml instead. This is
the better solution and should have been done in the first place.

Closes #30 