### PR TITLE
Dynamically determine hostname for MaaS checks

### DIFF
--- a/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/playbooks/roles/rpc_maas/tasks/local.yml
@@ -28,7 +28,7 @@
 - include: local_setup.yml
   vars:
     check_name: cinder_scheduler_check
-    check_details: file=cinder_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=cinder_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -40,7 +40,7 @@
 - include: local_setup.yml
   vars:
     check_name: cinder_volume_check
-    check_details: file=cinder_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=cinder_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -148,7 +148,7 @@
 - include: local_setup.yml
   vars:
     check_name: neutron_dhcp_agent_check
-    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -160,7 +160,7 @@
 - include: local_setup.yml
   vars:
     check_name: neutron_l3_agent_check
-    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -172,7 +172,7 @@
 - include: local_setup.yml
   vars:
     check_name: neutron_linuxbridge_agent_check
-    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -184,7 +184,7 @@
 - include: local_setup.yml
   vars:
     check_name: neutron_metadata_agent_check
-    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -196,7 +196,7 @@
 - include: local_setup.yml
   vars:
     check_name: neutron_metering_agent_check
-    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=neutron_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -232,7 +232,7 @@
 - include: local_setup.yml
   vars:
     check_name: nova_compute_check
-    check_details: file=nova_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=nova_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -244,7 +244,7 @@
 - include: local_setup.yml
   vars:
     check_name: nova_cert_check
-    check_details: file=nova_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=nova_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -256,7 +256,7 @@
 - include: local_setup.yml
   vars:
     check_name: nova_conductor_check
-    check_details: file=nova_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=nova_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -268,7 +268,7 @@
 - include: local_setup.yml
   vars:
     check_name: nova_scheduler_check
-    check_details: file=nova_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=nova_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -280,7 +280,7 @@
 - include: local_setup.yml
   vars:
     check_name: nova_consoleauth_check
-    check_details: file=nova_service_check.py,args=--host,args={{ ansible_fqdn }},args={{ internal_vip_address }}
+    check_details: file=nova_service_check.py,args=--host,args={{ ansible_nodename }},args={{ internal_vip_address }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:


### PR DESCRIPTION
Currently, we assume hosts returned from a `nova service-list` and
`neutron agent-list` are FQDNs which is an incorrect assumption. The
original change was made as we ran these MaaS-related playbooks/roles
on hosts w/ incorrectly configured hostnames (meaning a `hostname`
would return the FQDN), and therefore the hosts being returned from the
above two commands were FQDNs.

This change replaces references to ansible_fqdn to ansible_nodename,
which uses a python platform.node() to obtain the hostname. This should
allow us to properly configure MaaS irrespective of whether or not an
installation has correctly configured hostnames on the individual nodes.

Closes issue #9