### PR TITLE
Quote maas_external_ip_address's value

### DIFF
--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -23,7 +23,7 @@ maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
 maas_notification_plan: npManaged
-maas_external_ip_address: {{ external_vip_address }}
+maas_external_ip_address: "{{ external_vip_address }}"
 
 # By default we will create an agent token for each entity, however if you'd
 # prefer to use the same agent token for all entities then specify it here


### PR DESCRIPTION
Currently, we have this in playbooks/roles/rpc_maas/defaults/main.yml:

maas_external_ip_address: {{ external_vip_address }}

This is throwing an ansible syntax error.  The simple solution, as the
error suggests, is to wrap {{ external_vip_address }} in double-quotes.

Closes issue #32