### PR TITLE
Install mariadb-client and configure .my.cnf

### DIFF
--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -88,6 +88,7 @@ maas_apt_repos:
 
 maas_apt_packages:
   - rackspace-monitoring-agent
+  - mariadb-client
 
 maas_pip_requirements_file: "/usr/lib/rackspace-monitoring-agent/plugins/requirements.txt"
 

--- a/playbooks/roles/rpc_maas/tasks/create_my_cnf.yml
+++ b/playbooks/roles/rpc_maas/tasks/create_my_cnf.yml
@@ -1,0 +1,23 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Drop local .my.cnf file
+  template:
+    src: "client.my.cnf.j2"
+    dest: "/root/.my.cnf"
+    owner: "root"
+    group: "root"
+    mode: "0600"
+  delegate_to: "{{ physical_host }}"

--- a/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/playbooks/roles/rpc_maas/tasks/main.yml
@@ -25,6 +25,10 @@
   when: >
     inventory_hostname in groups['hosts']
 
+- include: create_my_cnf.yml
+  when: >
+    inventory_hostname in groups['galera']
+
 - include: raxmon_cli_config.yml
   when: >
     inventory_hostname in groups['hosts']

--- a/playbooks/roles/rpc_maas/templates/client.my.cnf.j2
+++ b/playbooks/roles/rpc_maas/templates/client.my.cnf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+[client]
+host={{ container_address }}
+user={{ galera_root_user }}
+password={{ galera_root_password }}


### PR DESCRIPTION
Current master of os-ansible-deployment no longer does either on
physical hosts, resulting in our galera checks failing (since they are
run on the physical).  This change installs mariadb-client on all
physical hosts and drops a .my.cnf on those physical nodes that have a
galera container running on them.

Closes issue #35