### PR TITLE
Add rpc_support_holland_password to secrets file

### DIFF
--- a/etc/openstack_deploy/user_extras_secrets.yml
+++ b/etc/openstack_deploy/user_extras_secrets.yml
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 maas_keystone_password:
+rpc_support_holland_password:


### PR DESCRIPTION
This commit adds an empty value to
etc/openstack_deploy/user_extras_secrets.yml so that the operator gets
a sane default value when the file is run through pw-token-gen.py.

Failing to define this value (as is the current state) results in an
ansible run failure when you run the rpc-support.yml playbook.

Closes #40