### PR TITLE
Add monitoring of nf_conntrack_count

### DIFF
--- a/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/playbooks/roles/rpc_maas/tasks/main.yml
@@ -66,3 +66,7 @@
     external_vip_address: "{{ external_lb_vip_address }}"
   when: >
     inventory_hostname == groups['utility'][0] and ssl_check == true
+
+- include: network.yml
+  when: >
+    inventory_hostname in groups['hosts']

--- a/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/playbooks/roles/rpc_maas/tasks/network.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: local_setup.yml
+  vars:
+    check_name: conntrack_count
+    check_details: file={{ check_name }}.py
+    check_period: "{{ maas_check_period }}"
+    check_timeout: "{{ maas_check_timeout }}"
+    alarms:
+      - { 'name': 'conntrack_count_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric["ip_conntrack_count"], metric["ip_conntrack_max"]) > 90) { return new AlarmStatus(CRITICAL, "Connection count is > 90% of maximum allowed."); }' }
+  user: root

--- a/playbooks/roles/rpc_maas/tasks/network.yml
+++ b/playbooks/roles/rpc_maas/tasks/network.yml
@@ -20,5 +20,5 @@
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
-      - { 'name': 'conntrack_count_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric["ip_conntrack_count"], metric["ip_conntrack_max"]) > 90) { return new AlarmStatus(CRITICAL, "Connection count is > 90% of maximum allowed."); }' }
+      - { 'name': 'conntrack_count_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric["nf_conntrack_count"], metric["nf_conntrack_max"]) > 90) { return new AlarmStatus(CRITICAL, "Connection count is > 90% of maximum allowed."); }' }
   user: root


### PR DESCRIPTION
This commit sets up monitoring using the conntrack_count.py plugin.
An alarm is set to alert when the value of nf_conntrack_count is
greater than 90% of nf_conntrack_max.

A new task file for network related monitoring is created called
network.yml and called by main.yml for the rpc_maas role.

Issue: https://github.com/rcbops/rpc-maas/issues/163