### PR TITLE
Add playbook for configuring hp_monitoring.py

### DIFF
--- a/etc/openstack_deploy/user_extras_variables.yml
+++ b/etc/openstack_deploy/user_extras_variables.yml
@@ -45,6 +45,7 @@ maas_target_alias: public0_v4
 ssl_check: false
 dell_check: false
 remote_check: true
+hp_check: false
 
 # Set the LB device name in CORE
 lb_name: 'unspecified'

--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -100,6 +100,7 @@ dell_check: false
 # remote_check: This flag indicates if the remote.http checks and alarms should be deployed.
 #
 remote_check: true
+hp_check: false
 
 #
 # lb_name: Defines the entity name of the load balancing device against which the remote MaaS

--- a/playbooks/roles/rpc_maas/tasks/hardware_setup.yml
+++ b/playbooks/roles/rpc_maas/tasks/hardware_setup.yml
@@ -1,0 +1,45 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Get entity ID for physical_host
+  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  register: entity_id
+
+- name: Validate if check exists
+  shell: raxmon-checks-list --entity-id {{ entity_id.stdout|quote }} | grep "label={{ check_name|quote }}--{{ inventory_hostname|quote }}"
+  register: check_exists
+  ignore_errors: True
+
+- name: Create check if it does not exist
+  command: raxmon-checks-create --entity-id {{ entity_id.stdout }} --type agent.plugin --label {{ check_name }}--{{ inventory_hostname }} --details {{ check_details }} --period {{ check_period }} --timeout {{ check_timeout }}
+  when: check_exists|failed
+
+- name: Get check ID for newly created check
+  shell: raxmon-checks-list --entity-id {{ entity_id.stdout|quote }} | grep "label={{ check_name|quote }}--{{ inventory_hostname|quote }}" | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  register: check_id
+
+- name: Validate if alarm exists
+  shell: raxmon-alarms-list --entity-id {{ entity_id.stdout|quote }} | grep "label={{ item.name|quote }}--{{ inventory_hostname|quote }}"
+  register: alarm_exists
+  ignore_errors: True
+  when: alarms is defined
+  with_items: alarms
+
+- name: Create alarm if it does not exist
+  shell: raxmon-alarms-create --entity-id {{ entity_id.stdout|quote }} --check-id {{ check_id.stdout|quote }} --notification-plan {{ maas_notification_plan }} --label {{ item[1].name|quote }}--{{ inventory_hostname|quote }} --criteria {{ item[1].criteria|quote }}
+  when: item[0]|failed and alarms is defined
+  with_together:
+    - alarm_exists.results
+    - alarms

--- a/playbooks/roles/rpc_maas/tasks/hp.yml
+++ b/playbooks/roles/rpc_maas/tasks/hp.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: hardware_setup.yml
+  vars:
+    check_name: hp-memory
+    file_name: hp_monitoring
+    check_details: file={{ file_name }}.py
+    check_period: "{{ maas_check_period }}"
+    check_timeout: "{{ maas_check_timeout }}"
+    alarms:
+      - { 'name': 'hardware_memory_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["hardware_memory_status"] != 1) { return new AlarmStatus(CRITICAL, "Physical Memory Error"); }' }
+
+- include: hardware_setup.yml
+  vars:
+    check_name: hp-processors
+    file_name: hp_monitoring
+    check_details: file={{ file_name }}.py
+    check_period: "{{ maas_check_period }}"
+    check_timeout: "{{ maas_check_timeout }}"
+    alarms:
+      - { 'name': 'hardware_processors_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["hardware_processors_status"] != 1) { return new AlarmStatus(CRITICAL, "Physical Processor Error"); }' }
+
+- include: hardware_setup.yml
+  vars:
+    check_name: hp-disk
+    file_name: hp_monitoring
+    check_details: file={{ file_name }}.py
+    check_period: "{{ maas_check_period }}"
+    check_timeout: "{{ maas_check_timeout }}"
+    alarms:
+      - { 'name': 'hardware_disk_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["hardware_disk_status"] != 1) { return new AlarmStatus(CRITICAL, "Physical Disk Error"); }' }

--- a/playbooks/roles/rpc_maas/tasks/main.yml
+++ b/playbooks/roles/rpc_maas/tasks/main.yml
@@ -70,3 +70,7 @@
 - include: network.yml
   when: >
     inventory_hostname in groups['hosts']
+
+- include: hp.yml
+  when: >
+    inventory_hostname in groups['hosts'] and hp_check == true


### PR DESCRIPTION
This commit configures the monitoring plugin hp_monitoring.py when the
var hp_check == true. This is for creating monitoring checks/alarms on
HP hardware that are equivalent to those for Dell.

The plugin is being added to rpc-maas as part of pull request
https://github.com/rcbops/rpc-maas/pull/187