### PR TITLE
Add usage procedure to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ Optional add-ons for Rackspace Private Cloud
 
 The rpc-extras repo includes add-ons for the Rackspace Private Cloud product
 that integrate with the 
-[os-ansible-deploy](https://github.com/stackforge/os-ansible-deployment)
+[os-ansible-deployment](https://github.com/stackforge/os-ansible-deployment)
 set of Ansible playbooks and roles.
 These add-ons extend the 'vanilla' OpenStack environment with value-added
 features that Rackspace has found useful, but are not core to deploying an
 OpenStack cloud.
 
 # Ansible Playbooks
+
+Plays:
 
 * `horizon_extensions.yml` - rebrands the horizon dashboard for Rackspace,
 as well as adding a Rackspace tab and a Solutions tab, which provides
@@ -22,6 +24,31 @@ miscellaneous tasks helpful to support personnel.
 * `setup-maas.yml` - deploys, sets up, and installs Rackspace
 [MaaS](http://www.rackspace.com/cloud/monitoring) checks
 for Rackspace Private Clouds.
+* `site.yml` - deploys all the above playbooks.
+
+Basic Setup:
+
+1. Complete an installation of
+[os-ansible-deployment](https://github.com/stackforge/os-ansible-deployment)
+as per the standard mechanism described there.
+2. Clone this repository.
+3. Copy `rpc-extras/etc/openstack_deploy/*` to
+`/etc/openstack_deploy/`.
+4. Set the `rpc_repo_path` in
+`/etc/openstack_deploy/user_extras_variables.yml` to the path of the
+`os-ansible-deployment` repository clone directory.
+5. Set all other variables in
+`/etc/openstack_deploy/user_extras_variables.yml` appropriately.
+6. Generate the random passwords for the extras by executing
+`scripts/pw-token-gen.py --file
+/etc/openstack_deploy/user_extras_secrets.yml` from the
+`os-ansible-deployment` clone directory.
+7. Change to the `rpc-extras/playbooks/` directory and execute your
+desired plays.  IE:
+
+```bash
+openstack-ansible setup-everything.yml
+```
 
 # Ansible Roles
 


### PR DESCRIPTION
This commit adds the procedure for using rpc-extras to the README.