### PR TITLE
Add ElasticSearch role

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OpenStack cloud.
 
 Plays:
 
+* `elasticsearch.yml` - deploys an elasticsearch host
 * `horizon_extensions.yml` - rebrands the horizon dashboard for Rackspace,
 as well as adding a Rackspace tab and a Solutions tab, which provides
 Heat templates for commonly deployed applications.
@@ -61,6 +62,7 @@ openstack-ansible site.yml
 
 # Ansible Roles
 
+* `elasticsearch`
 * `horizon_extensions`
 * `rpc_maas`
 * `rpc_support`

--- a/etc/openstack_deploy/env.d/elasticsearch.yml
+++ b/etc/openstack_deploy/env.d/elasticsearch.yml
@@ -1,0 +1,15 @@
+---
+component_skel:
+  elasticsearch:
+    belongs_to:
+      - elasticsearch_all
+
+container_skel:
+  elasticsearch_container:
+    belongs_to:
+      - log_containers
+    contains:
+      - elasticsearch
+    properties:
+      service_name: elasticsearch
+      container_release: trusty

--- a/etc/openstack_deploy/user_extras_variables.yml
+++ b/etc/openstack_deploy/user_extras_variables.yml
@@ -74,3 +74,7 @@ maas_filesystem_threshold: 90.0
 #    threshold: 90.0
 #  - filesystem: /boot
 #    threshold: 90.0
+
+# For an AIO it's recommended to set the following to limit the expected RAM
+# usage of elasticsearch.
+# elasticsearch_heap_size_mb: 1024

--- a/playbooks/elasticsearch.yml
+++ b/playbooks/elasticsearch.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Setup ElasticSearch host
+  hosts: elasticsearch_all
+  user: root
+  pre_tasks:
+    - name: Create ElasticSearch data directory on host
+      file:
+        path: "/openstack/{{ container_name }}/var/lib/elasticsearch"
+        state: directory
+        group: "root"
+        owner: "root"
+        mode:  "0755"
+        recurse: no
+      delegate_to: "{{ physical_host }}"
+      when: is_metal == false or is_metal == "False"
+    - name: ElasticSearch extra lxc config
+      lxc_container:
+        name: "{{ container_name }}"
+        container_command: |
+          [[ ! -d "/var/lib/elasticsearch" ]] && mkdir -p "/var/lib/elasticsearch"
+        container_config:
+          - "lxc.mount.entry=/openstack/{{ container_name
+            }}/var/lib/elasticsearch var/lib/elasticsearch none bind 0 0"
+          - "lxc.aa_profile=unconfined"
+      delegate_to: "{{ physical_host }}"
+      when: is_metal == false or is_metal == "False"
+      tags:
+        - elasticsearch-pre-install
+    - name: Flush net cache
+      command: /usr/local/bin/lxc-system-manage flush-net-cache
+      delegate_to: "{{ physical_host }}"
+      when: is_metal == false or is_metal == "False"
+      tags:
+        - elasticsearch-pre-install
+    - name: Wait for container ssh
+      wait_for:
+        port: "22"
+        delay: 5
+        host: "{{ container_address }}"
+      delegate_to: "{{ physical_host }}"
+      when: is_metal == false or is_metal == "False"
+      tags:
+        - elasticsearch-pre-install
+  roles:
+    - { role: "elasticsearch" }
+  vars:
+    is_metal: "{{ properties.is_metal|default(false) }}"

--- a/playbooks/roles/elasticsearch/CONTRIBUTING.rst
+++ b/playbooks/roles/elasticsearch/CONTRIBUTING.rst
@@ -1,0 +1,81 @@
+Rackspace Private Cloud
+#######################
+:tags: openstack, rpc, cloud, ansible
+:category: \*nix
+
+contributor guidelines
+^^^^^^^^^^^^^^^^^^^^^^
+
+Filing Bugs
+-----------
+
+Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+
+
+When submitting a bug, or working on a bug, please ensure the following criteria are met:
+    * The description clearly states or describes the original problem or root cause of the problem.
+    * Include historical information on how the problem was identified.
+    * Any relevant logs are included.
+    * The provided information should be totally self-contained. External access to web services/sites should not be needed.
+    * Steps to reproduce the problem if possible.
+
+
+Submitting Code
+---------------
+
+Submit a PR directly to GitHub which will then be reviewed and merged where appropriate.
+
+Extra
+-----
+
+Tags:
+    If it's a bug that needs fixing in a branch in addition to Master, add a '\<release\>-backport-potential' tag (eg ``juno-backport-potential``).  There are predefined tags that will autocomplete.
+
+Status:
+    Please leave this alone, it should be New till someone triages the issue.
+
+Importance:
+    Should only be touched if it is a Blocker/Gating issue. If it is, please set to High, and only use Critical if you have found a bug that can take down whole infrastructures.
+
+
+Style guide
+-----------
+
+When creating tasks and other roles for use in Ansible please create then using the YAML dictionary format.
+
+Example YAML dictionary format:
+    .. code-block:: yaml
+
+        - name: The name of the tasks
+          module_name:
+            thing1: "some-stuff"
+            thing2: "some-other-stuff"
+          tags:
+            - some-tag
+            - some-other-tag
+
+
+Example **NOT** in YAML dictionary format:
+    .. code-block:: yaml
+
+        - name: The name of the tasks
+          module_name: thing1="some-stuff" thing2="some-other-stuff"
+          tags:
+            - some-tag
+            - some-other-tag
+
+
+Usage of the ">" and "|" operators should be limited to Ansible conditionals and command modules such as the ansible ``shell`` module.
+
+
+Issues
+------
+
+When submitting an issue, or working on an issue please ensure the following criteria are met:
+    * The description clearly states or describes the original problem or root cause of the problem.
+    * Include historical information on how the problem was identified.
+    * Any relevant logs are included.
+    * If the issue is a bug that needs fixing in a branch other than Master, add the ‘backport potential’ tag TO THE ISSUE (not the PR).
+    * The provided information should be totally self-contained. External access to web services/sites should not be needed.
+    * If the issue is needed for a hotfix release, add the 'expedite' label.
+    * Steps to reproduce the problem if possible.

--- a/playbooks/roles/elasticsearch/LICENSE
+++ b/playbooks/roles/elasticsearch/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/playbooks/roles/elasticsearch/README.rst
+++ b/playbooks/roles/elasticsearch/README.rst
@@ -1,0 +1,14 @@
+Ansible Elasticsearch Role
+##########################
+:tags: rackspace, rpc, cloud, ansible, elasticsearch
+:category: \*nix
+
+Role for the deployment of Elasticsearch within Rackspace Private Cloud.
+
+.. code-block:: yaml
+
+    - name: Setup elasticsearch host
+      hosts: elasticsearch_all
+      user: root
+      roles:
+        - { role: "elasticsearch" }

--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+elasticsearch_apt_repo_url: "http://packages.elasticsearch.org/elasticsearch/1.5/debian"
+
+elasticsearch_apt_repos:
+  - { repo: "deb {{ elasticsearch_apt_repo_url }} stable main", state: "present" }
+
+elasticsearch_apt_keys:
+  - { url: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch", state: "present" }
+
+elasticsearch_apt_packages:
+  - elasticsearch
+  - openjdk-7-jre-headless
+
+elasticsearch_pip_packages:
+  - elasticsearch-curator
+
+# This sets the cluster name
+elasticsearch_cluster: openstack
+
+# This sets the default HTTP port to listen on
+elasticsearch_http_port: 9200
+
+# This sets the default TCP port to listen on
+elasticsearch_tcp_port: 9300
+
+# Change this to 'true' will ensure that elasticsearch never uses swap space
+elasticsearch_bootstrap_mlockall: "false"
+
+# Change this to override the default value (which is 50% of total memory)
+# elasticsearch_heap_size_mb: 1024
+
+# Change this to override the default value (which is the same value as
+# elasticsearch_heap_size_mb). if mlockall is set to true this setting
+# is intentionally set to 'unlimited' instead.
+# elasticsearch_max_locked_memory_mb: 1024
+
+# This sets the retention period for data in ElasticSearch
+elasticsearch_prune_days: 90
+
+# Note that this effectively disables the distributed features
+# If you're expanding beyond one node these should be adjusted
+elasticsearch_index_number_of_shards: 1
+elasticsearch_index_number_of_replicas: 0

--- a/playbooks/roles/elasticsearch/handlers/main.yml
+++ b/playbooks/roles/elasticsearch/handlers/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Restart ElasticSearch
+  service:
+    name: elasticsearch
+    state: restarted
+    pattern: elasticsearch

--- a/playbooks/roles/elasticsearch/meta/main.yml
+++ b/playbooks/roles/elasticsearch/meta/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: rcbops
+  description: Installation of Elasticsearch
+  company: Rackspace
+  license: Apache2
+  min_ansible_version: 1.6.6
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+  categories:
+    - rackspace
+    - elasticsearch
+
+dependencies:
+  - pip_install

--- a/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
+++ b/playbooks/roles/elasticsearch/tasks/elasticsearch_install.yml
@@ -1,0 +1,86 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install apt packages
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+  register: install_apt_packages
+  until: install_apt_packages|success
+  retries: 5
+  delay: 2
+  with_items: elasticsearch_apt_packages
+  tags:
+    - elasticsearch-apt-packages
+    - elasticsearch-install
+
+- name: Install pip packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  register: install_pip_packages
+  until: install_pip_packages|success
+  retries: 5
+  delay: 2
+  with_items: elasticsearch_pip_packages
+  tags:
+    - elasticsearch-pip-packages
+    - elasticsearch-install
+
+- name: Install ElasticHQ Plugin
+  command: ./plugin -install {{ item }}
+  args:
+    chdir: /usr/share/elasticsearch/bin
+    creates: /usr/share/elasticsearch/plugins/HQ
+  with_items:
+    - royrusso/elasticsearch-HQ
+  tags:
+    - elasticsearch-plugins
+    - elasticsearch-install
+
+- name: Install Kopf Plugin
+  command: ./plugin -install {{ item }}
+  args:
+    chdir: /usr/share/elasticsearch/bin
+    creates: /usr/share/elasticsearch/plugins/kopf
+  with_items:
+    - lmenezes/elasticsearch-kopf
+  tags:
+    - elasticsearch-plugins
+    - elasticsearch-install
+
+- name: Install Head Plugin
+  command: ./plugin -install {{ item }}
+  args:
+    chdir: /usr/share/elasticsearch/bin
+    creates: /usr/share/elasticsearch/plugins/head
+  with_items:
+    - mobz/elasticsearch-head
+  tags:
+    - elasticsearch-plugins
+    - elasticsearch-install
+
+- name: Install BigDesk Plugin
+  command: ./plugin -install {{ item }}
+  args:
+    chdir: /usr/share/elasticsearch/bin
+    creates: /usr/share/elasticsearch/plugins/bigdesk
+  with_items:
+    - lukas-vlcek/bigdesk/2.4.0
+  tags:
+    - elasticsearch-plugins
+    - elasticsearch-install

--- a/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
+++ b/playbooks/roles/elasticsearch/tasks/elasticsearch_post_install.yml
@@ -1,0 +1,75 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Deploy ElasticSearch configuration files
+  template:
+    src: "{{ item }}"
+    dest: "/etc/elasticsearch/{{ item }}"
+    owner: "root"
+    group: "root"
+  with_items:
+    - elasticsearch.yml
+    - logging.yml
+  notify: Restart ElasticSearch
+  tags:
+    - elasticsearch-post-install
+
+- name: Deploy ElasticSearch service configuration file
+  template:
+    src: "{{ item }}"
+    dest: "/etc/default/{{ item }}"
+    owner: "root"
+    group: "root"
+  with_items:
+    - elasticsearch
+  notify: Restart ElasticSearch
+  tags:
+    - elasticsearch-post-install
+
+- name: Restart ElasticSearch before proceeding
+  meta: flush_handlers
+
+- name: Wait for ElasticSearch port
+  wait_for:
+    host: "{{ ansible_ssh_host }}"
+    port: "9200"
+  tags:
+    - elasticsearch-post-install
+
+- name: Deploy ElasticSearch schema mapping script
+  template:
+    src: "mapping.sh.j2"
+    dest: "/opt/mapping.sh"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  tags:
+    - elasticsearch-post-install
+
+- name: Run ElasticSearch schema mapping script
+  shell: /opt/mapping.sh
+  tags:
+    - elasticsearch-post-install
+
+- name: Setup the ElasticSearch Curator cron job
+  cron:
+    name: "ElasticSearch Curator"
+    minute: 0
+    hour: 0
+    user: "root"
+    job: "/usr/local/bin/curator --host {{ hostvars[inventory_hostname]['container_address'] }} delete --older_than {{ elasticsearch_prune_days }}"
+    cron_file: "elasticsearch_curator"
+  tags:
+    - elasticsearch-post-install

--- a/playbooks/roles/elasticsearch/tasks/elasticsearch_pre_install.yml
+++ b/playbooks/roles/elasticsearch/tasks/elasticsearch_pre_install.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add apt keys
+  apt_key:
+    url: "{{ item.url }}"
+    state: "{{ item.state }}"
+  with_items: elasticsearch_apt_keys
+  when: elasticsearch_apt_keys is defined
+  register: add_keys_url
+  until: add_keys_url|success
+  retries: 5
+  delay: 2
+  tags:
+    - elasticsearch-apt-keys
+    - elasticsearch-pre-install
+
+- name: Add apt repositories
+  apt_repository:
+    repo: "{{ item.repo }}"
+    state: "{{ item.state }}"
+  with_items: elasticsearch_apt_repos
+  register: add_repos
+  until: add_repos|success
+  retries: 5
+  delay: 2
+  tags:
+    - elasticsearch-apt-repos
+    - elasticsearch-pre-install

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: elasticsearch_pre_install.yml
+- include: elasticsearch_install.yml
+- include: elasticsearch_post_install.yml

--- a/playbooks/roles/elasticsearch/templates/elasticsearch
+++ b/playbooks/roles/elasticsearch/templates/elasticsearch
@@ -1,0 +1,59 @@
+# Run Elasticsearch as this user ID and group ID
+#ES_USER=elasticsearch
+#ES_GROUP=elasticsearch
+
+# Heap Size  (defaults to 256m min, 1g max)
+{% if elasticsearch_heap_size_mb is not defined %}
+{%   set memtotal_mb = hostvars[inventory_hostname]['ansible_memtotal_mb']|int %}
+{%   if memtotal_mb <= 32768 %}
+{%     set elasticsearch_heap_size_mb = memtotal_mb // 2 %}
+{%   else %}
+{%     set elasticsearch_heap_size_mb = 16384 %}
+{%   endif %}
+{% endif %}
+ES_HEAP_SIZE={{ elasticsearch_heap_size_mb|int }}m
+
+# Heap new generation
+#ES_HEAP_NEWSIZE=
+
+# max direct memory
+#ES_DIRECT_SIZE=16g
+
+# Maximum number of open files, defaults to 65535.
+#MAX_OPEN_FILES=65535
+
+# Maximum locked memory size. Set to "unlimited" if you use the
+# bootstrap.mlockall option in elasticsearch.yml. You must also set
+# ES_HEAP_SIZE.
+{% if elasticsearch_bootstrap_mlockall == true %}
+{%   set elasticsearch_max_locked_memory_mb = "unlimited" %}
+{% endif %}
+{% if elasticsearch_max_locked_memory_mb is not defined %}
+{%   set elasticsearch_max_locked_memory_mb = elasticsearch_heap_size_mb %}
+{% endif %}
+MAX_LOCKED_MEMORY={{ elasticsearch_max_locked_memory_mb }}
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+#MAX_MAP_COUNT=262144
+
+# Elasticsearch log directory
+#LOG_DIR=/var/log/elasticsearch
+
+# Elasticsearch data directory
+#DATA_DIR=/var/lib/elasticsearch
+
+# Elasticsearch work directory
+#WORK_DIR=/tmp/elasticsearch
+
+# Elasticsearch configuration directory
+#CONF_DIR=/etc/elasticsearch
+
+# Elasticsearch configuration file (elasticsearch.yml)
+#CONF_FILE=/etc/elasticsearch/elasticsearch.yml
+
+# Additional Java OPTS
+#ES_JAVA_OPTS=
+
+# Configure restart on package upgrade (true, every other setting will lead to
+# not restarting)
+#RESTART_ON_UPGRADE=true

--- a/playbooks/roles/elasticsearch/templates/elasticsearch.yml
+++ b/playbooks/roles/elasticsearch/templates/elasticsearch.yml
@@ -1,0 +1,405 @@
+##################### Elasticsearch Configuration Example #####################
+
+# This file contains an overview of various configuration settings,
+# targeted at operations staff. Application developers should
+# consult the guide at <http://elasticsearch.org/guide>.
+#
+# The installation procedure is covered at
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
+#
+# Elasticsearch comes with reasonable defaults for most settings,
+# so you can try it out without bothering with configuration.
+#
+# Most of the time, these defaults are just fine for running a production
+# cluster. If you're fine-tuning your cluster, or wondering about the
+# effect of certain configuration option, please _do ask_ on the
+# mailing list or IRC channel [http://elasticsearch.org/community].
+
+# Any element in the configuration can be replaced with environment variables
+# by placing them in ${...} notation. For example:
+#
+#node.rack: ${RACK_ENV_VAR}
+
+# For information on supported formats and syntax for the config file, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
+
+
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+cluster.name: {{ elasticsearch_cluster }}
+
+
+#################################### Node #####################################
+
+# Node names are generated dynamically on startup, so you're relieved
+# from configuring them manually. You can tie this node to a specific name:
+#
+#node.name: "Franz Kafka"
+
+# Every node can be configured to allow or deny being eligible as the master,
+# and to allow or deny to store the data.
+#
+# Allow this node to be eligible as a master node (enabled by default):
+#
+#node.master: true
+#
+# Allow this node to store data (enabled by default):
+#
+#node.data: true
+
+# You can exploit these settings to design advanced cluster topologies.
+#
+# 1. You want this node to never become a master node, only to hold data.
+#    This will be the "workhorse" of your cluster.
+#
+#node.master: false
+#node.data: true
+#
+# 2. You want this node to only serve as a master: to not store any data and
+#    to have free resources. This will be the "coordinator" of your cluster.
+#
+#node.master: true
+#node.data: false
+#
+# 3. You want this node to be neither master nor data node, but
+#    to act as a "search load balancer" (fetching data from nodes,
+#    aggregating results, etc.)
+#
+#node.master: false
+#node.data: false
+
+# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
+# Node Info API [http://localhost:9200/_nodes] or GUI tools
+# such as <http://www.elasticsearch.org/overview/marvel/>,
+# <http://github.com/karmi/elasticsearch-paramedic>,
+# <http://github.com/lukas-vlcek/bigdesk> and
+# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
+
+# A node can have generic attributes associated with it, which can later be
+# used
+# for customized shard allocation filtering, or allocation awareness. An
+# attribute
+# is a simple key value pair, similar to node.key: value, here is an example:
+#
+#node.rack: rack314
+
+# By default, multiple nodes are allowed to start from the same installation
+# location
+# to disable it, set the following:
+#node.max_local_storage_nodes: 1
+
+
+#################################### Index ####################################
+
+# You can set a number of options (such as shard/replica options, mapping
+# or analyzer definitions, translog settings, ...) for indices globally,
+# in this file.
+#
+# Note, that it makes more sense to configure index settings specifically for
+# a certain index, either when creating it or by using the index templates
+# API.
+#
+# See
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules.html>
+# and
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html>
+# for more information.
+
+# Set the number of shards (splits) of an index (5 by default):
+#
+index.number_of_shards: {{ elasticsearch_index_number_of_shards }}
+
+# Set the number of replicas (additional copies) of an index (1 by default):
+#
+index.number_of_replicas: {{ elasticsearch_index_number_of_replicas }}
+
+# Note, that for development on a local machine, with small indices, it
+# usually
+# makes sense to "disable" the distributed features:
+#
+#index.number_of_shards: 1
+#index.number_of_replicas: 0
+
+# These settings directly affect the performance of index and search
+# operations
+# in your cluster. Assuming you have enough machines to hold shards and
+# replicas, the rule of thumb is:
+#
+# 1. Having more *shards* enhances the _indexing_ performance and allows to
+#    _distribute_ a big index across machines.
+# 2. Having more *replicas* enhances the _search_ performance and improves the
+#    cluster _availability_.
+#
+# The "number_of_shards" is a one-time setting for an index.
+#
+# The "number_of_replicas" can be increased or decreased anytime,
+# by using the Index Update Settings API.
+#
+# Elasticsearch takes care about load balancing, relocating, gathering the
+# results from nodes, etc. Experiment with different settings to fine-tune
+# your setup.
+
+# Use the Index Status API (<http://localhost:9200/A/_status>) to inspect
+# the index status.
+
+
+#################################### Paths ####################################
+
+# Path to directory containing configuration (this file and logging.yml):
+#
+#path.conf: /path/to/conf
+
+# Path to directory where to store index data allocated for this node.
+#
+#path.data: /path/to/data
+#
+# Can optionally include more than one location, causing data to be striped
+# across
+# the locations (a la RAID 0) on a file level, favouring locations with most
+# free
+# space on creation. For example:
+#
+#path.data: /path/to/data1,/path/to/data2
+
+# Path to temporary files:
+#
+#path.work: /path/to/work
+
+# Path to log files:
+#
+#path.logs: /path/to/logs
+
+# Path to where plugins are installed:
+#
+#path.plugins: /path/to/plugins
+
+
+#################################### Plugin ###################################
+
+# If a plugin listed here is not installed for current node, the node will not
+# start.
+#
+#plugin.mandatory: mapper-attachments,lang-groovy
+
+
+################################### Memory ####################################
+
+# Elasticsearch performs poorly when JVM starts swapping: you should ensure
+# that
+# it _never_ swaps.
+#
+# Set this property to true to lock the memory:
+#
+bootstrap.mlockall: {{ elasticsearch_bootstrap_mlockall }}
+
+# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
+# to the same value, and that the machine has enough memory to allocate
+# for Elasticsearch, leaving enough memory for the operating system itself.
+#
+# You should also make sure that the Elasticsearch process is allowed to lock
+# the memory, eg. by using `ulimit -l unlimited`.
+
+
+############################## Network And HTTP ###############################
+
+# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
+# on port [9200-9300] for HTTP traffic and on port [9300-9400] for
+# node-to-node
+# communication. (the range means that if the port is busy, it will
+# automatically
+# try the next port).
+
+# Set the bind address specifically (IPv4 or IPv6):
+#
+network.bind_host: {{ hostvars[inventory_hostname]['container_address'] }}
+
+# Set the address other nodes will use to communicate with this node. If not
+# set, it is automatically derived. It must point to an actual IP address.
+#
+network.publish_host: {{ hostvars[inventory_hostname]['container_address'] }}
+
+# Set both 'bind_host' and 'publish_host':
+#
+#network.host: 192.168.0.1
+
+# Set a custom port for the node to node communication (9300 by default):
+#
+transport.tcp.port: {{ elasticsearch_tcp_port }}
+
+# Enable compression for all communication between nodes (disabled by
+# default):
+#
+#transport.tcp.compress: true
+
+# Set a custom port to listen for HTTP traffic:
+#
+http.port: {{ elasticsearch_http_port }}
+
+# Set a custom allowed content length:
+#
+#http.max_content_length: 100mb
+
+# Disable HTTP completely:
+#
+#http.enabled: false
+
+
+################################### Gateway ###################################
+
+# The gateway allows for persisting the cluster state between full cluster
+# restarts. Every change to the state (such as adding an index) will be stored
+# in the gateway, and when the cluster starts up for the first time,
+# it will read its state from the gateway.
+
+# There are several types of gateway implementations. For more information,
+# see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-gateway.html>.
+
+# The default gateway type is the "local" gateway (recommended):
+#
+#gateway.type: local
+
+# Settings below control how and when to start the initial recovery process on
+# a full cluster restart (to reuse as much local data as possible when using
+# shared
+# gateway).
+
+# Allow recovery process after N nodes in a cluster are up:
+#
+#gateway.recover_after_nodes: 1
+
+# Set the timeout to initiate the recovery process, once the N nodes
+# from previous setting are up (accepts time value):
+#
+#gateway.recover_after_time: 5m
+
+# Set how many nodes are expected in this cluster. Once these N nodes
+# are up (and recover_after_nodes is met), begin recovery process immediately
+# (without waiting for recover_after_time to expire):
+#
+#gateway.expected_nodes: 2
+
+
+############################# Recovery Throttling #############################
+
+# These settings allow to control the process of shards allocation between
+# nodes during initial recovery, replica allocation, rebalancing,
+# or when adding and removing nodes.
+
+# Set the number of concurrent recoveries happening on a node:
+#
+# 1. During the initial recovery
+#
+#cluster.routing.allocation.node_initial_primaries_recoveries: 4
+#
+# 2. During adding/removing nodes, rebalancing, etc
+#
+#cluster.routing.allocation.node_concurrent_recoveries: 2
+
+# Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
+#
+#indices.recovery.max_bytes_per_sec: 20mb
+
+# Set to limit the number of open concurrent streams when
+# recovering a shard from a peer:
+#
+#indices.recovery.concurrent_streams: 5
+
+
+################################## Discovery ##################################
+
+# Discovery infrastructure ensures nodes can be found within a cluster
+# and master node is elected. Multicast discovery is the default.
+
+# Set to ensure a node sees N other master eligible nodes to be considered
+# operational within the cluster. Its recommended to set it to a higher value
+# than 1 when running more than 2 nodes in the cluster.
+#
+#discovery.zen.minimum_master_nodes: 1
+
+# Set the time to wait for ping responses from other nodes when discovering.
+# Set this option to a higher value on a slow or congested network
+# to minimize discovery failures:
+#
+#discovery.zen.ping.timeout: 3s
+
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
+
+# Unicast discovery allows to explicitly control which nodes will be used
+# to discover the cluster. It can be used when multicast is not present,
+# or to restrict the cluster communication-wise.
+#
+# 1. Disable multicast discovery (enabled by default):
+#
+#discovery.zen.ping.multicast.enabled: false
+#
+# 2. Configure an initial list of master nodes in the cluster
+#    to perform discovery when new nodes (master or data) are started:
+#
+#discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
+
+# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
+#
+# You have to install the cloud-aws plugin for enabling the EC2 discovery.
+#
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-ec2.html>
+#
+# See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
+# for a step-by-step tutorial.
+
+# GCE discovery allows to use Google Compute Engine API in order to perform
+# discovery.
+#
+# You have to install the cloud-gce plugin for enabling the GCE discovery.
+#
+# For more information, see
+# <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
+
+# Azure discovery allows to use Azure API in order to perform discovery.
+#
+# You have to install the cloud-azure plugin for enabling the Azure discovery.
+#
+# For more information, see
+# <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
+
+################################## Slow Log ##################################
+
+# Shard level query and fetch threshold logging.
+
+#index.search.slowlog.threshold.query.warn: 10s
+#index.search.slowlog.threshold.query.info: 5s
+#index.search.slowlog.threshold.query.debug: 2s
+#index.search.slowlog.threshold.query.trace: 500ms
+
+#index.search.slowlog.threshold.fetch.warn: 1s
+#index.search.slowlog.threshold.fetch.info: 800ms
+#index.search.slowlog.threshold.fetch.debug: 500ms
+#index.search.slowlog.threshold.fetch.trace: 200ms
+
+#index.indexing.slowlog.threshold.index.warn: 10s
+#index.indexing.slowlog.threshold.index.info: 5s
+#index.indexing.slowlog.threshold.index.debug: 2s
+#index.indexing.slowlog.threshold.index.trace: 500ms
+
+################################## GC Logging ################################
+
+#monitor.jvm.gc.young.warn: 1000ms
+#monitor.jvm.gc.young.info: 700ms
+#monitor.jvm.gc.young.debug: 400ms
+
+#monitor.jvm.gc.old.warn: 10s
+#monitor.jvm.gc.old.info: 5s
+#monitor.jvm.gc.old.debug: 2s
+
+################################## Security ################################
+
+# Uncomment if you want to enable JSONP as a valid return transport on the
+# http server. With this enabled, it may pose a security risk, so disabling
+# it unless you need it is recommended (it is disabled by default).
+#
+#http.jsonp.enable: true

--- a/playbooks/roles/elasticsearch/templates/logging.yml
+++ b/playbooks/roles/elasticsearch/templates/logging.yml
@@ -1,0 +1,56 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console, file
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+  # gateway
+  #gateway: DEBUG
+  #index.gateway: DEBUG
+
+  # peer shard recovery
+  #indices.recovery: DEBUG
+
+  # discovery
+  #discovery: TRACE
+
+  index.search.slowlog: TRACE, index_search_slow_log_file
+  index.indexing.slowlog: TRACE, index_indexing_slow_log_file
+
+additivity:
+  index.search.slowlog: false
+  index.indexing.slowlog: false
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_search_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_index_search_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_indexing_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/playbooks/roles/elasticsearch/templates/mapping.sh.j2
+++ b/playbooks/roles/elasticsearch/templates/mapping.sh.j2
@@ -1,0 +1,302 @@
+#!/bin/sh
+curl --retry 10 -XPUT 'http://{{ hostvars[inventory_hostname]['container_address'] }}:{{ elasticsearch_http_port }}/_template/log_test1' -d '
+{
+  "template" : "*",
+  "order": 0,
+    "mappings" : {
+      "_default_" : {
+        "dynamic_templates" : [ {
+          "string_fields" : {
+            "mapping" : {
+              "index" : "analyzed",
+              "omit_norms" : true,
+              "type" : "string",
+              "fields" : {
+                "raw" : {
+                  "index" : "not_analyzed",
+                  "ignore_above" : 256,
+                  "type" : "string"
+                }
+              }
+            },
+            "match" : "*",
+            "match_mapping_type" : "string"
+          }
+        } ],
+        "properties" : {
+          "@version" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "geoip" : {
+            "dynamic" : "true",
+            "properties" : {
+              "location" : {
+                "type" : "geo_point"
+              }
+            }
+          }
+        }
+      },
+      "logs" : {
+        "dynamic_templates" : [ {
+          "string_fields" : {
+            "mapping" : {
+              "index" : "analyzed",
+              "omit_norms" : true,
+              "type" : "string",
+              "fields" : {
+                "raw" : {
+                  "index" : "not_analyzed",
+                  "ignore_above" : 256,
+                  "type" : "string"
+                }
+              }
+            },
+            "match" : "*",
+            "match_mapping_type" : "string"
+          }
+        } ],
+        "properties" : {
+          "@fields" : {
+            "properties" : {
+              "facility" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "processid" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "program" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              },
+              "severity" : {
+                "type" : "string",
+                "norms" : {
+                  "enabled" : false
+                },
+                "fields" : {
+                  "raw" : {
+                    "type" : "string",
+                    "index" : "not_analyzed",
+                    "ignore_above" : 256
+                  }
+                }
+              }
+            }
+          },
+          "@message" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "@source" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "@source_host" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "@timestamp" : {
+            "type" : "date",
+            "format" : "dateOptionalTime"
+          },
+          "@version" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          },
+          "facility" : {
+            "type" : "long"
+          },
+          "facility_label" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "geoip" : {
+            "dynamic" : "true",
+            "properties" : {
+              "location" : {
+                "type" : "geo_point"
+              }
+            }
+          },
+          "host" : {
+            "type" : "ip",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_level" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_program" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_program_path" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_program_pid" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "os_timestamp" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "priority" : {
+            "type" : "long"
+          },
+          "severity" : {
+            "type" : "long"
+          },
+          "severity_label" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "tags" : {
+            "type" : "string",
+            "norms" : {
+              "enabled" : false
+            },
+            "fields" : {
+              "raw" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "ignore_above" : 256
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -2,3 +2,4 @@
 - include: horizon_extensions.yml
 - include: rpc-support.yml
 - include: setup-maas.yml
+- include: elasticsearch.yml


### PR DESCRIPTION
This implements the elasticsearch role which was in the juno branch of
os-ansible-deployment with some minor changes:

* Converted to use the Ansible Galaxy structure
* All variables are namespaced
* ElasticSearch v1.5 is deployed (this is an upgrade from Juno which deployed
v1.4)
* ElasticSearch v1.5 configuration updates
* The HTTP listening port can be set
* The number of shards and replicas can be set
* The role is divided and tagged into task groupings:
  - pre-install
  - install
  - post-install
* The patch adds an optional env.d file which can be used to implement
      elasticsearch in containers on the logging host.

Note that the pip configuration does not use the locked-down
os-ansible-deployment python repository as there is currently no simple
mechanism to include the required python wheels for rpc-extras.