### PR TITLE
Clean up roles/rpc_maas/defaults/main.yml

### DIFF
--- a/etc/openstack_deploy/user_extras_variables.yml
+++ b/etc/openstack_deploy/user_extras_variables.yml
@@ -13,17 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+## Rackspace Cloud Details
+rackspace_cloud_auth_url: https://identity.api.rackspacecloud.com/v2.0
+rackspace_cloud_tenant_id: SomeTenantID
+rackspace_cloud_username: SomeUserName
+rackspace_cloud_password: SomeUsersPassword
+rackspace_cloud_api_key: SomeAPIKey
+
 ## MaaS Options
 # rpc_maas/defaults/main.yml contains vars that can be overridden here.
 
 # Set maas_auth_method to 'token' to use maas_auth_token/maas_api_url
 # instead of maas_username/maas_api_key
 maas_auth_method: password
+maas_tenant_id: "{{ rackspace_cloud_tenant_id }}"
 maas_auth_url: "{{ rackspace_cloud_auth_url }}"
 maas_username: "{{ rackspace_cloud_username }}"
 maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
-maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
 maas_notification_plan: npManaged
 
 # Where is the os-ansible deployment repo?

--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -17,11 +17,12 @@
 # Set maas_auth_method to 'token' to use maas_auth_token/maas_api_url
 # instead of maas_username/maas_api_key
 maas_auth_method: password
-maas_auth_url: "{{ rackspace_cloud_auth_url }}"
-maas_username: "{{ rackspace_cloud_username }}"
-maas_api_key: "{{ rackspace_cloud_api_key }}"
+maas_auth_url: https://identity.api.rackspacecloud.com/v2.0
+maas_tenant_id: SomeTenantID
+maas_username: SomeUserName
+maas_api_key: SomeAPIKey
 maas_auth_token: some_token
-maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
+maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ maas_tenant_id }}
 maas_notification_plan: npManaged
 maas_external_ip_address: "{{ external_vip_address }}"
 


### PR DESCRIPTION
Currently, roles/rpc_maas/defaults/main.yml has variables which point
to other rackspace-related variables that are no longer defaulted in
os-ansible-deployment's user_variables.yml file.  This change updates
roles/rpc_maas/defaults/main.yml to point to generic (static) values,
while also adding a new maas_tenant_id variable for the Rackspace Cloud
tenant ID (this avoids the need of having to override the maas_api_url
variable).  Additionally, we create some defaults for the
rackspace-related variables in user_extras_variables.yml (we have other
overrides in user_extras_variables.yml which area already pointing to
these).

On a side note, the reason for retaining the rackspace-related
variables is so that user_variables.yml overrides for configuring
glance CloudFiles backend can also point to these rackspace-related
variables.  This will avoid having to maintain two sets of Rackspace
details in your overrides files.

Closes issue #58