### PR TITLE
Add Kibana role for rpc-extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Plays:
 * `horizon_extensions.yml` - rebrands the horizon dashboard for Rackspace,
 as well as adding a Rackspace tab and a Solutions tab, which provides
 Heat templates for commonly deployed applications.
+* `kibana.yml` - Setup Kibana on the Kibana hosts for the logging dashboard.
 * `rpc-support.yml` - provides holland backup service, support SSH key
 distribution, custom security group rules, bashrc settings, and other
 miscellaneous tasks helpful to support personnel.
@@ -55,5 +56,6 @@ openstack-ansible setup-everything.yml
 # Ansible Roles
 
 * `horizon_extensions`
+* `kibana`
 * `rpc_maas`
 * `rpc_support`

--- a/etc/openstack_deploy/env.d/kibana.yml
+++ b/etc/openstack_deploy/env.d/kibana.yml
@@ -1,0 +1,15 @@
+---
+component_skel:
+  kibana:
+    belongs_to:
+      - kibana_all
+
+container_skel:
+  kibana_container:
+    belongs_to:
+      - log_containers
+    contains:
+      - kibana
+    properties:
+      service_name: kibana
+      container_release: trusty

--- a/playbooks/kibana.yml
+++ b/playbooks/kibana.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
+- name: Setup Kibana host
+  hosts: kibana_all
+  user: root
+  roles:
+    - { role: "kibana" }

--- a/playbooks/roles/kibana/CONTRIBUTING.rst
+++ b/playbooks/roles/kibana/CONTRIBUTING.rst
@@ -1,0 +1,81 @@
+Rackspace Private Cloud
+#######################
+:tags: openstack, rpc, cloud, ansible
+:category: \*nix
+
+contributor guidelines
+^^^^^^^^^^^^^^^^^^^^^^
+
+Filing Bugs
+-----------
+
+Bugs should be filed on GitHub: "https://github.com/rcbops/rcbops-extras"
+
+
+When submitting a bug, or working on a bug, please ensure the following criteria are met:
+    * The description clearly states or describes the original problem or root cause of the problem.
+    * Include historical information on how the problem was identified.
+    * Any relevant logs are included.
+    * The provided information should be totally self-contained. External access to web services/sites should not be needed.
+    * Steps to reproduce the problem if possible.
+
+
+Submitting Code
+---------------
+
+Submit a PR directly to GitHub which will then be reviewed and merged where appropriate.
+
+Extra
+-----
+
+Tags:
+    If it's a bug that needs fixing in a branch in addition to Master, add a '\<release\>-backport-potential' tag (eg ``juno-backport-potential``).  There are predefined tags that will autocomplete.
+
+Status:
+    Please leave this alone, it should be New till someone triages the issue.
+
+Importance:
+    Should only be touched if it is a Blocker/Gating issue. If it is, please set to High, and only use Critical if you have found a bug that can take down whole infrastructures.
+
+
+Style guide
+-----------
+
+When creating tasks and other roles for use in Ansible please create then using the YAML dictionary format.
+
+Example YAML dictionary format:
+    .. code-block:: yaml
+
+        - name: The name of the tasks
+          module_name:
+            thing1: "some-stuff"
+            thing2: "some-other-stuff"
+          tags:
+            - some-tag
+            - some-other-tag
+
+
+Example **NOT** in YAML dictionary format:
+    .. code-block:: yaml
+
+        - name: The name of the tasks
+          module_name: thing1="some-stuff" thing2="some-other-stuff"
+          tags:
+            - some-tag
+            - some-other-tag
+
+
+Usage of the ">" and "|" operators should be limited to Ansible conditionals and command modules such as the ansible ``shell`` module.
+
+
+Issues
+------
+
+When submitting an issue, or working on an issue please ensure the following criteria are met:
+    * The description clearly states or describes the original problem or root cause of the problem.
+    * Include historical information on how the problem was identified.
+    * Any relevant logs are included.
+    * If the issue is a bug that needs fixing in a branch other than Master, add the ‘backport potential’ tag TO THE ISSUE (not the PR).
+    * The provided information should be totally self-contained. External access to web services/sites should not be needed.
+    * If the issue is needed for a hotfix release, add the 'expedite' label.
+    * Steps to reproduce the problem if possible.

--- a/playbooks/roles/kibana/LICENSE
+++ b/playbooks/roles/kibana/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/playbooks/roles/kibana/README.rst
+++ b/playbooks/roles/kibana/README.rst
@@ -1,0 +1,14 @@
+Ansible Kibana Role
+##########################
+:tags: rackspace, rpc, cloud, ansible, kibana
+:category: \*nix
+
+Role for the deployment of Kibana within Rackspace Private Cloud.
+
+.. code-block:: yaml
+
+    - name: Setup Kibana host
+      hosts: kibana_all
+      user: root
+      roles:
+        - { role: "kibana" }

--- a/playbooks/roles/kibana/defaults/main.yml
+++ b/playbooks/roles/kibana/defaults/main.yml
@@ -1,0 +1,52 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kibana_root: /opt/kibana
+kibana_version: "kibana-3.1.0"
+kibana_url: "https://download.elasticsearch.org/kibana/kibana/{{ kibana_version }}.tar.gz"
+kibana_sha256sum: "059a4b6b507b9ff771901d12035e499b0e8d1cae7d9e5284633e19da6c294e07"
+
+elasticsearch_http_port: 9200
+elasticsearch_vip: "{{ internal_lb_vip_address }}"
+
+kibana_apt_packages:
+  - apache2
+  - python-passlib
+
+kibana_apache_modules:
+  - rewrite
+  - ssl
+  - proxy
+  - proxy_http
+
+kibana_debug: False
+kibana_verbose: True
+
+kibana_server_name: "{{ external_lb_vip_address }}"
+kibana_self_signed: true
+kibana_ssl_port: 8443
+kibana_system_user: www-user
+kibana_system_group: www-data
+kibana_log_level: info
+kibana_ssl_cert: '/etc/ssl/certs/apache.cert'
+kibana_ssl_key: '/etc/ssl/private/apache.key'
+kibana_ssl_cert_path: '/etc/ssl/certs'
+kibana_ssl_protocol: '{{ ssl_protocol|default("ALL -SSLv2 -SSLv3") }}'
+kibana_ssl_cipher_suite: '{{ ssl_cipher_suite|default("ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS") }}'
+
+
+# Directories to create
+kibana_directories:
+  - { name: /var/log/kibana, mode: 755 }

--- a/playbooks/roles/kibana/handlers/main.yml
+++ b/playbooks/roles/kibana/handlers/main.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
+- name: Restart Apache
+  service:
+    name: apache2
+    state: restarted
+    pattern: apache2

--- a/playbooks/roles/kibana/meta/main.yml
+++ b/playbooks/roles/kibana/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
+galaxy_info:
+  author: rcbops
+  description: Installation of Kibana
+  company: Rackspace
+  license: Apache2
+  min_ansible_version: 1.6.6
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+  categories:
+    - rackspace
+    - kibana

--- a/playbooks/roles/kibana/tasks/kibana_install.yml
+++ b/playbooks/roles/kibana/tasks/kibana_install.yml
@@ -13,6 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
+- name: Download Kibana
+  get_url:
+    url: "{{ kibana_url }}"
+    dest: "/tmp/kibana.tar.gz"
+    mode: "0644"
+  tags: kibana-install
+
+- name: Extract Kibana
+  unarchive:
+    copy: "no"
+    src: "/tmp/kibana.tar.gz"
+    dest: "/opt"
+  tags: kibana-install
+
+- name: Link Kibana Directory
+  file:
+    state: "link"
+    src: "/opt/{{ kibana_version }}"
+    dest: "{{ kibana_root }}"
+    owner: "{{ kibana_system_user }}"
+    group: "{{ kibana_system_group }}"
+  tags: kibana-install

--- a/playbooks/roles/kibana/tasks/kibana_post_install.yml
+++ b/playbooks/roles/kibana/tasks/kibana_post_install.yml
@@ -1,0 +1,122 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: create self-signed SSL cert
+  command: >
+    openssl req -new -nodes -x509 -subj
+    "/C=US/ST=Texas/L=San Antonio/O=IT/CN={{ kibana_server_name }}"
+    -days 365
+    -keyout /etc/ssl/private/apache.key
+    -out /etc/ssl/certs/apache.cert
+    -extensions v3_ca
+    creates=/etc/ssl/certs/apache.cert
+  when: kibana_self_signed is defined and kibana_self_signed == true
+  tags:
+    - kibana-self-signed-cert
+    - kibana-post-install
+
+- name: Enable apache modules
+  command: a2enmod "{{ item }}"
+  with_items: kibana_apache_modules
+  tags:
+    - kibana-apache-modules
+    - kibana-apache
+    - kibana-post-install
+
+- name: Template Kibana Apache Config
+  template:
+    src: "{{ item }}"
+    dest: "/etc/apache2/sites-available/{{ item }}"
+    owner: "{{ kibana_system_user }}"
+    group: "{{ kibana_system_group }}"
+  with_items:
+    - 000-kibana.conf
+  notify: Restart Apache
+  tags:
+    - kibana-apache
+    - kibana-post-install
+
+- name: Drop Apache2 Ports File
+  template:
+    src: "{{ item }}"
+    dest: "/etc/apache2/{{ item }}"
+    owner: "root"
+    group: "root"
+  with_items:
+    - ports.conf
+  notify: Restart Apache
+  tags:
+    - kibana-apache
+    - kibana-post-install
+
+- name: Kibana Config
+  template:
+    src: "{{ item }}"
+    dest: "{{ kibana_root }}/{{ item }}"
+    owner: "{{ kibana_system_user }}"
+    group: "{{ kibana_system_group }}"
+  with_items:
+    - config.js
+  notify: Restart Apache
+  tags:
+    - kibana-post-install
+
+- name: Link Kibana Site
+  file:
+    state: "link"
+    src: "/etc/apache2/sites-available/000-kibana.conf"
+    dest: "/etc/apache2/sites-enabled/000-kibana.conf"
+    owner: "{{ kibana_system_user }}"
+    group: "{{ kibana_system_group }}"
+  notify: Restart Apache
+  tags:
+    - kibana-apache
+    - kibana-post-install
+
+- name: Remove Apache Default Site
+  file:
+    state: "absent"
+    path: "/etc/apache2/sites-enabled/000-default.conf"
+  notify: Restart Apache
+  tags:
+    - kibana-apache
+    - kibana-config
+
+- name: Create kibana http_auth user
+  htpasswd:
+    path: "/etc/apache2/users"
+    name: "kibana"
+    password: "{{ kibana_password }}"
+    owner: "root"
+    group: "www-data"
+    mode: "0640"
+    create: "yes"
+    state: "present"
+  notify: Restart Apache
+  tags:
+    - kibana-apache
+    - kibana-post-install
+
+- name: Install Dashboards
+  template:
+    src: "{{ item }}"
+    dest: "/opt/kibana/app/dashboards/{{ item }}"
+    owner: "root"
+    group: "root"
+  with_items:
+    - Event-Dashboard.json
+  tags:
+    - kibana-post-install

--- a/playbooks/roles/kibana/tasks/kibana_pre_install.yml
+++ b/playbooks/roles/kibana/tasks/kibana_pre_install.yml
@@ -1,0 +1,62 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install Kibana apt packages
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+  register: install_apt_packages
+  until: install_apt_packages|success
+  retries: 5
+  delay: 2
+  with_items: kibana_apt_packages
+  tags:
+    - kibana-apt-packages
+    - kibana-pre-install
+
+- name: Create the Kibana System Group
+  group:
+    name: "{{ kibana_system_group }}"
+    state: "present"
+    system: "yes"
+  when: kibana_system_group is defined
+  tags:
+    - kibana-pre-install
+
+- name: Create the Kibana System User
+  user:
+    name: "{{ kibana_system_user }}"
+    shell: "/bin/false"
+    group: "{{ kibana_system_group }}"
+    groups: adm
+    home: "/var/lib/{{ kibana_system_user }}"
+    system: "yes"
+    createhome: "yes"
+  when: kibana_system_group is defined and kibana_system_user is defined
+  tags:
+    - kibana-pre-install
+
+- name: Create Kibana Directories
+  file:
+    state: directory
+    path: "{{item.name}}"
+    mode: "{{item.mode}}"
+    owner: "{{kibana_system_user}}"
+    group: "{{kibana_system_group}}"
+  with_items: kibana_directories
+  tags:
+    - kibana-pre-install

--- a/playbooks/roles/kibana/tasks/main.yml
+++ b/playbooks/roles/kibana/tasks/main.yml
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-maas_keystone_password:
-rpc_support_holland_password:
-kibana_password:
+- include: kibana_pre_install.yml
+- include: kibana_install.yml
+- include: kibana_post_install.yml

--- a/playbooks/roles/kibana/templates/000-kibana.conf
+++ b/playbooks/roles/kibana/templates/000-kibana.conf
@@ -1,0 +1,48 @@
+<VirtualHost *:80>
+    ServerName {{ kibana_server_name }}
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^/?(.*) https://%{HTTP_HOST}:{{ kibana_ssl_port }}/$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:{{ kibana_ssl_port }}>
+    ServerName {{ kibana_server_name }}
+
+    LogLevel  {{  kibana_log_level|default('info') }}
+    ErrorLog  /var/log/apache2/kibana-error.log
+    CustomLog /var/log/apache2/ssl_access.log combined
+    Options +FollowSymLinks
+
+    SSLEngine on
+    SSLCompression off
+    SSLCertificateFile    {{ kibana_ssl_cert }}
+    SSLCertificateKeyFile {{ kibana_ssl_key }}
+    SSLCACertificatePath  {{ kibana_ssl_cert_path }}
+    SSLCARevocationPath   {{ kibana_ssl_cert_path }}
+    SSLProtocol {{ kibana_ssl_protocol }}
+    SSLHonorCipherOrder On
+    SSLCipherSuite {{ kibana_ssl_cipher_suite }}
+    SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown
+
+    DocumentRoot {{ kibana_root }}
+
+    <Directory />
+      Options FollowSymLinks
+      AllowOverride None
+    </Directory>
+
+    # ElasticSearch Reverse Proxy
+    <Location /elasticsearch/>
+        ProxyPass http://{{ elasticsearch_vip }}:{{ elasticsearch_http_port }}/
+        ProxyPassReverse /
+    </Location>
+
+    <Directory {{ kibana_root }}>
+      Options Indexes FollowSymLinks MultiViews
+      AllowOverride AuthConfig
+      AuthType Basic
+      AuthName Kibana
+      AuthUserFile /etc/apache2/users
+      Require user kibana
+    </Directory>
+</VirtualHost>

--- a/playbooks/roles/kibana/templates/Event-Dashboard.json
+++ b/playbooks/roles/kibana/templates/Event-Dashboard.json
@@ -1,0 +1,633 @@
+{
+  "title": "Event Dashboard",
+  "services": {
+    "query": {
+      "list": {
+        "0": {
+          "id": 0,
+          "color": "#7EB26D",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:nova*"
+        },
+        "1": {
+          "id": 1,
+          "color": "#EAB839",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:cinder*"
+        },
+        "2": {
+          "id": 2,
+          "color": "#6ED0E0",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:neutron*"
+        },
+        "3": {
+          "id": 3,
+          "color": "#EF843C",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:keystone*"
+        },
+        "4": {
+          "id": 4,
+          "color": "#1F78C1",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:swift*"
+        },
+        "5": {
+          "id": 5,
+          "color": "#BA43A9",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:horizon*"
+        },
+        "6": {
+          "id": 6,
+          "color": "#C15C17",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:heat*"
+        },
+        "7": {
+          "id": 7,
+          "color": "#629E51",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:openstack AND httptime:*"
+        },
+        "8": {
+          "id": 8,
+          "color": "#EAB839",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:infrastructure"
+        }
+      },
+      "ids": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    "filter": {
+      "list": {
+        "0": {
+          "type": "time",
+          "field": "@timestamp",
+          "from": "now-5m",
+          "to": "now",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 0
+        }
+      },
+      "ids": [
+        0
+      ]
+    }
+  },
+  "rows": [
+    {
+      "title": "Graph",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "group": [
+            "default"
+          ],
+          "type": "histogram",
+          "mode": "count",
+          "time_field": "@timestamp",
+          "value_field": null,
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "10s",
+          "fill": 3,
+          "linewidth": 3,
+          "timezone": "browser",
+          "spyable": true,
+          "zoomlinks": false,
+          "bars": true,
+          "stack": true,
+          "points": false,
+          "lines": false,
+          "legend": false,
+          "x-axis": true,
+          "y-axis": true,
+          "percentage": false,
+          "interactive": true,
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ]
+          },
+          "title": "OpenStack Events",
+          "intervals": [
+            "auto",
+            "10s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1M",
+            "1y"
+          ],
+          "options": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "pointradius": 5,
+          "show_query": true,
+          "legend_counts": true,
+          "zerofill": true,
+          "derivative": false
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "httptime",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": "1000",
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              7
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "10s",
+          "intervals": [
+            "auto",
+            "10s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 3,
+          "bars": false,
+          "stack": true,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": false,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "OpenStack API Response (ms)"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "count",
+          "time_field": "@timestamp",
+          "value_field": null,
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              8
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "10s",
+          "intervals": [
+            "auto",
+            "10s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": false,
+          "fill": 0,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": true,
+          "stack": true,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Infrastructure Events"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Services",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "error": false,
+          "span": 4,
+          "editable": true,
+          "type": "terms",
+          "loadingEditor": false,
+          "field": "os_level",
+          "exclude": [],
+          "missing": false,
+          "other": false,
+          "size": 10,
+          "order": "count",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "arrangement": "horizontal",
+          "chart": "pie",
+          "counter_pos": "above",
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "tmode": "terms",
+          "tstat": "total",
+          "valuefield": "",
+          "title": "Severity"
+        },
+        {
+          "error": false,
+          "span": 4,
+          "editable": true,
+          "type": "terms",
+          "loadingEditor": false,
+          "field": "os_program",
+          "exclude": [],
+          "missing": false,
+          "other": false,
+          "size": 5,
+          "order": "count",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "arrangement": "horizontal",
+          "chart": "pie",
+          "counter_pos": "above",
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "tmode": "terms",
+          "tstat": "total",
+          "valuefield": "",
+          "title": "Top 5 Event Sources"
+        },
+        {
+          "error": false,
+          "span": 4,
+          "editable": true,
+          "type": "terms",
+          "loadingEditor": false,
+          "field": "verb",
+          "exclude": [],
+          "missing": false,
+          "other": false,
+          "size": 10,
+          "order": "count",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": false,
+          "tilt": false,
+          "labels": true,
+          "arrangement": "horizontal",
+          "chart": "pie",
+          "counter_pos": "above",
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "tmode": "terms",
+          "tstat": "total",
+          "valuefield": "",
+          "title": "API Operations"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Events",
+      "height": "350px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "title": "All events",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "group": [
+            "default"
+          ],
+          "type": "table",
+          "size": 100,
+          "pages": 5,
+          "offset": 0,
+          "sort": [
+            "@timestamp",
+            "desc"
+          ],
+          "style": {
+            "font-size": "9pt"
+          },
+          "overflow": "min-height",
+          "fields": [
+            "@timestamp",
+            "os_program",
+            "os_level",
+            "host",
+            "openstack_message"
+          ],
+          "localTime": true,
+          "timeField": "@timestamp",
+          "highlight": [],
+          "sortable": true,
+          "header": true,
+          "paging": true,
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ]
+          },
+          "field_list": true,
+          "status": "Stable",
+          "trimFactor": 300,
+          "normTimes": true,
+          "all_fields": false
+        }
+      ],
+      "notice": false
+    }
+  ],
+  "editable": true,
+  "failover": false,
+  "index": {
+    "interval": "day",
+    "pattern": "[logstash-]YYYY.MM.DD",
+    "default": "NO_TIME_FILTER_OR_INDEX_PATTERN_NOT_MATCHED",
+    "warm_fields": true
+  },
+  "style": "dark",
+  "panel_hints": true,
+  "pulldowns": [
+    {
+      "type": "query",
+      "collapse": true,
+      "notice": false,
+      "query": "*",
+      "pinned": true,
+      "history": [],
+      "remember": 10,
+      "enable": true
+    },
+    {
+      "type": "filtering",
+      "collapse": true,
+      "notice": false,
+      "enable": true
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "timefield": "@timestamp",
+      "now": true,
+      "filter_id": 0,
+      "enable": true
+    }
+  ],
+  "loader": {
+    "save_gist": false,
+    "save_elasticsearch": true,
+    "save_local": true,
+    "save_default": true,
+    "save_temp": true,
+    "save_temp_ttl_enable": true,
+    "save_temp_ttl": "30d",
+    "load_gist": true,
+    "load_elasticsearch": true,
+    "load_elasticsearch_size": 20,
+    "load_local": true,
+    "hide": false
+  },
+  "refresh": "5s"
+}

--- a/playbooks/roles/kibana/templates/config.js
+++ b/playbooks/roles/kibana/templates/config.js
@@ -1,0 +1,80 @@
+/** @scratch /configuration/config.js/1
+ *
+ * == Configuration
+ * config.js is where you will find the core Kibana configuration. This file contains parameter that
+ * must be set before kibana is run for the first time.
+ */
+define(['settings'],
+function (Settings) {
+
+
+  /** @scratch /configuration/config.js/2
+   *
+   * === Parameters
+   */
+  return new Settings({
+
+    /** @scratch /configuration/config.js/5
+     *
+     * ==== elasticsearch
+     *
+     * The URL to your elasticsearch server. You almost certainly don't
+     * want +http://localhost:9200+ here. Even if Kibana and Elasticsearch are on
+     * the same host. By default this will attempt to reach ES at the same host you have
+     * kibana installed on. You probably want to set it to the FQDN of your
+     * elasticsearch host
+     *
+     * Note: this can also be an object if you want to pass options to the http client. For example:
+     *
+     *  +elasticsearch: {server: "http://localhost:9200", withCredentials: true}+
+     *
+     */
+    elasticsearch: "https://{{ external_lb_vip_address }}:8443/elasticsearch/",
+
+    /** @scratch /configuration/config.js/5
+     *
+     * ==== default_route
+     *
+     * This is the default landing page when you don't specify a dashboard to load. You can specify
+     * files, scripts or saved dashboards here. For example, if you had saved a dashboard called
+     * `WebLogs' to elasticsearch you might use:
+     *
+     * default_route: '/dashboard/elasticsearch/WebLogs',
+     */
+    default_route     : '/dashboard/file/Event-Dashboard.json',
+
+    /** @scratch /configuration/config.js/5
+     *
+     * ==== kibana-int
+     *
+     * The default ES index to use for storing Kibana specific object
+     * such as stored dashboards
+     */
+    kibana_index: "kibana-int",
+
+    /** @scratch /configuration/config.js/5
+     *
+     * ==== panel_name
+     *
+     * An array of panel modules available. Panels will only be loaded when they are defined in the
+     * dashboard, but this list is used in the "add panel" interface.
+     */
+    panel_names: [
+      'histogram',
+      'map',
+      'goal',
+      'table',
+      'filtering',
+      'timepicker',
+      'text',
+      'hits',
+      'column',
+      'trends',
+      'bettermap',
+      'query',
+      'terms',
+      'stats',
+      'sparklines'
+    ]
+  });
+});

--- a/playbooks/roles/kibana/templates/ports.conf
+++ b/playbooks/roles/kibana/templates/ports.conf
@@ -1,0 +1,13 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 80
+
+<IfModule ssl_module>
+    Listen {{ kibana_ssl_port }}
+</IfModule>
+
+<IfModule mod_gnutls.c>
+    Listen {{ kibana_ssl_port }}
+</IfModule>


### PR DESCRIPTION
Add Kibana role and setup to rpc-extras
* Converted from os-ansible-deployment juno branch
* Rworked some plays for formatting
* Moved the apache restart to be a handler
* Split into 3 tasks files:
  * pre-install
  * install
  * post-install

Note that the pip configuration does not use the locked-down
os-ansible-deployment python repository as there is currently nosimple
mechanism to include the required python wheels for rpc-extras.