### PR TITLE
Add Log Shipping rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ miscellaneous tasks helpful to support personnel.
 * `setup-maas.yml` - deploys, sets up, and installs Rackspace
 [MaaS](http://www.rackspace.com/cloud/monitoring) checks
 for Rackspace Private Clouds.
+* `setup-logging.yml` - deploys and configures Logstash, Elasticsearch, and 
+Kibana to tag, index, and expose aggregated logs from all hosts and containers
+in the deployment using the related plays mentioned above..
 * `site.yml` - deploys all the above playbooks.
 
 Basic Setup:

--- a/etc/openstack_deploy/user_extras_variables.yml
+++ b/etc/openstack_deploy/user_extras_variables.yml
@@ -78,3 +78,21 @@ maas_filesystem_threshold: 90.0
 # For an AIO it's recommended to set the following to limit the expected RAM
 # usage of elasticsearch.
 # elasticsearch_heap_size_mb: 1024
+
+# Ship all logs to the logstash container as well as the rsyslog_server
+logstash_port: 5544
+rsyslog_client_user_defined_targets:
+   - name: "rax-logging"
+     proto: "tcp"
+     port: "{{ logstash_port }}"
+     hostname: "groups['rsyslog_all'][0]"
+     action_options: 'ls_json'
+     template: >
+       $template ls_json,"{ %timestamp:::date-rfc3339,
+       jsonf:@timestamp%,%source:::
+       jsonf:@source_host%,\"@source\":\"syslog://%app-name:::
+       json%\",\"@message\":\"%msg:::
+       json%\",\"@fields\":{ %syslogfacility-text:::
+       jsonf:facility%,%syslogseverity-text:::jsonf:severity%,%app-name:::
+       jsonf:program%,%procid:::
+       jsonf:processid%}}"

--- a/playbooks/setup-logging.yml
+++ b/playbooks/setup-logging.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: logstash.yml
+- include: elasticsearch.yml
+- include: kibana.yml
+

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,5 +1,4 @@
----
 - include: horizon_extensions.yml
 - include: rpc-support.yml
 - include: setup-maas.yml
-- include: elasticsearch.yml
+- include: setup-logging.yml


### PR DESCRIPTION
Add definition needed by rsyslog client to ship logs to logstash also.
Define logstash_port as needed by the log shipping rule.
Add play to run all logging related tasks and related README change.