### PR TITLE
Rename nova_spice_console to nova_console

### DIFF
--- a/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/playbooks/roles/rpc_maas/tasks/local.yml
@@ -287,7 +287,7 @@
       - { 'name': 'nova_consoleauth_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["nova-consoleauth_status"] != 1) { return new AlarmStatus(CRITICAL, "nova-consoleauth down"); }' }
   user: root
   when: >
-    inventory_hostname in groups['nova_spice_console']
+    inventory_hostname in groups['nova_console']
 
 - include: local_setup.yml
   vars:
@@ -299,7 +299,7 @@
       - { 'name': 'nova_spice_api_local_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["nova_spice_api_local_status"] != 1) { return new AlarmStatus(CRITICAL, "API unavailable"); }' }
   user: root
   when: >
-    inventory_hostname in groups['nova_spice_console']
+    inventory_hostname in groups['nova_console']
 
 - include: local_setup.yml
   vars:


### PR DESCRIPTION
In commit 5cce6b5 in os-a-d, we renamed nova_spice_console group to
nova_console.  This commit updates rpc_maas so we correctly deploy
a check/alarm against the actual group.

Closes issue #69