### PR TITLE
Add Log Shipping rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,21 @@ Plays:
 as well as adding a Rackspace tab and a Solutions tab, which provides
 Heat templates for commonly deployed applications.
 * `kibana.yml` - Setup Kibana on the Kibana hosts for the logging dashboard.
-* `logstash.yml` - deploys a logstash host
+* `logstash.yml` - deploys a logstash host. If this play is used, be sure to 
+uncomment the related block in user_extra_variables.yml before this play is 
+run and then rerun the appropriate plays in os-ansible-deployment after this 
+play to ensure that rsyslog ships logs to logstash. See steps 11 - 13 below 
+for more.
 * `rpc-support.yml` - provides holland backup service, support SSH key
 distribution, custom security group rules, bashrc settings, and other
 miscellaneous tasks helpful to support personnel.
 * `setup-maas.yml` - deploys, sets up, and installs Rackspace
 [MaaS](http://www.rackspace.com/cloud/monitoring) checks
 for Rackspace Private Clouds.
+* `setup-logging.yml` - deploys and configures Logstash, Elasticsearch, and 
+Kibana to tag, index, and expose aggregated logs from all hosts and containers
+in the deployment using the related plays mentioned above. See steps 11 - 13 
+below for more.
 * `site.yml` - deploys all the above playbooks.
 
 Basic Setup:
@@ -46,8 +54,8 @@ os-ansible-deployment clone.
 `os-ansible-deployment` repository clone directory.
 7. Set all other variables in
 `/etc/openstack_deploy/user_extras_variables.yml` appropriately.
-7. Edit `rpc-extras/playbooks/ansible.cfg` and ensure the paths to the roles, playbooks and
-inventory are correct.
+8. Edit `rpc-extras/playbooks/ansible.cfg` and ensure the paths to the roles, 
+playbooks and inventory are correct.
 9. Generate the random passwords for the extras by executing
 `scripts/pw-token-gen.py --file
 /etc/openstack_deploy/user_extras_secrets.yml` from the
@@ -55,12 +63,20 @@ inventory are correct.
 10. Change to the `os-ansible-deployment/playbooks` directory and execute the
 plays. You can optionally execute `scripts/run-playbooks.sh` from the root of
 os-ansible-deployment clone.
-11. Change to the `rpc-extras/playbooks` directory and execute your
-desired plays.  IE:
-
+11. If you are planning to include the logstash play in the deployment, 
+uncomment the related yml block in user_extras_variables.yml now. 
+12. Change to the `rpc-extras/playbooks` directory and execute your
+desired plays.  IE: 
 ```bash
 openstack-ansible site.yml
 ```
+
+13. __Optional__ If the logstash play is included in the deployment, from the
+os-ansible-deployment/playbooks directory, run 
+```bash
+openstack-ansible setup-everything.yml --tags rsyslog-client
+``` to apply 
+the needed changes to rsyslog configurations to ship logs to logstash. 
 
 # Ansible Roles
 
@@ -70,3 +86,4 @@ openstack-ansible site.yml
 * `logstash`
 * `rpc_maas`
 * `rpc_support`
+

--- a/etc/openstack_deploy/user_extras_variables.yml
+++ b/etc/openstack_deploy/user_extras_variables.yml
@@ -79,3 +79,25 @@ maas_filesystem_threshold: 90.0
 # For an AIO it's recommended to set the following to limit the expected RAM
 # usage of elasticsearch.
 # elasticsearch_heap_size_mb: 1024
+
+# Ship all logs to the logstash container as well as the rsyslog_server.
+# Uncomment the following if the setup-logging play is going to be used.
+# logstash_port: 5544
+# rsyslog_client_user_defined_targets:
+#    - name: "rpc-logging"
+#      proto: "tcp"
+#      port: "{{ logstash_port }}"
+#      hostname: "{{ hostvars[groups['logstash'][0]]['container_address'] }}"
+#      action_options: 'ls_json'
+#      template: >
+#        $template ls_json,"{
+#        %timestamp:::date-rfc3339,jsonf:@timestamp%,
+#        %source:::jsonf:@source_host%,
+#        \"@source\":\"syslog://%app-name:::json%\",
+#        \"@message\":\"%msg:::json%\",
+#        \"@fields\": {
+#        %syslogfacility-text:::jsonf:facility%,
+#        %syslogseverity-text:::jsonf:severity%,
+#        %app-name:::jsonf:program%,
+#        %procid:::jsonf:processid% }
+#        }"

--- a/playbooks/setup-logging.yml
+++ b/playbooks/setup-logging.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: horizon_extensions.yml
-- include: rpc-support.yml
-- include: setup-maas.yml
-- include: setup-logging.yml
+- include: elasticsearch.yml
+- include: logstash.yml
+- include: kibana.yml


### PR DESCRIPTION
Add example definition needed by rsyslog client to ship logs to
logstash. Example defines logstash_port as needed by the log shipping
rule.
Add play to run all logging related tasks and related README change.
Update README to document all the steps necessary to successfully
deploy the ELK stack.