### PR TITLE
Run keystone module w/ token

### DIFF
--- a/playbooks/roles/rpc_maas/tasks/keystone_user.yml
+++ b/playbooks/roles/rpc_maas/tasks/keystone_user.yml
@@ -19,10 +19,8 @@
 - name: Create keystone user for monitoring
   keystone:
     command: "ensure_user"
-    login_user: "{{ keystone_service_user_name }}"
-    login_tenant_name: "{{ keystone_service_tenant_name }}"
-    login_password: "{{ keystone_auth_admin_password }}"
-    endpoint: "{{ keystone_service_internalurl }}"
+    token: "{{ keystone_auth_admin_token }}"
+    endpoint: "{{ keystone_service_adminurl }}"
     user_name: "{{ maas_keystone_user }}"
     tenant_name: "{{ keystone_admin_tenant_name }}"
     password: "{{ maas_keystone_password }}"
@@ -30,10 +28,8 @@
 - name: Add monitoring keystone user to admin role
   keystone:
     command: "ensure_user_role"
-    login_user: "{{ keystone_service_user_name }}"
-    login_tenant_name: "{{ keystone_service_tenant_name }}"
-    login_password: "{{ keystone_auth_admin_password }}"
-    endpoint: "{{ keystone_service_internalurl }}"
+    token: "{{ keystone_auth_admin_token }}"
+    endpoint: "{{ keystone_service_adminurl }}"
     user_name: "{{ maas_keystone_user }}"
     tenant_name: "{{ keystone_admin_tenant_name }}"
     role_name: "admin"


### PR DESCRIPTION
The fix for https://bugs.launchpad.net/openstack-ansible/+bug/1443955
breaks the tasks using the keystone module.  This commit updates the
rpc_maas role to use a token rather than the keystone service user when
interacting with keystone.  This is the pattern used in other os-a-d
roles.

Closes issue #74