### PR TITLE
Implement rpc-release file drop

### DIFF
--- a/playbooks/roles/rpc_support/defaults/main.yml
+++ b/playbooks/roles/rpc_support/defaults/main.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# RPC release version
+rpc_release: master
+
 # Packages required for support
 support_util_packages:
   - vim

--- a/playbooks/roles/rpc_support/tasks/main.yml
+++ b/playbooks/roles/rpc_support/tasks/main.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: rpc_release.yml
+
 - include: support_preinstall.yml
 
 - include: bashrc.yml

--- a/playbooks/roles/rpc_support/tasks/rpc_release.yml
+++ b/playbooks/roles/rpc_support/tasks/rpc_release.yml
@@ -1,0 +1,23 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Drop rpc-release file
+  template:
+    src: "rpc-release.j2"
+    dest: "/etc/rpc-release"
+    owner: "root"
+    group: "root"
+  tags:
+    - rpc-release

--- a/playbooks/roles/rpc_support/templates/rpc-release.j2
+++ b/playbooks/roles/rpc_support/templates/rpc-release.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+DISTRIB_ID="RPC"
+DISTRIB_RELEASE="{{ rpc_release }}"
+DISTRIB_CODENAME="wee-5ive"
+DISTRIB_DESCRIPTION="Rackspace Private Cloud powered by OpenStack"


### PR DESCRIPTION
This patch adds the drop of /etc/rpc-release into the support role as it's
expected that this role will be used in all RPC deployments, whereas the other
roles may be considered optional.