### PR TITLE
Add kernel modules, tuning and support packages for hosts

### DIFF
--- a/playbooks/roles/rpc_support/defaults/main.yml
+++ b/playbooks/roles/rpc_support/defaults/main.yml
@@ -18,13 +18,33 @@ rpc_release: master
 
 # Packages required for support
 support_util_packages:
-  - vim
-  - linux-crashdump
-  - iotop
+  - bridge-utils
+  - debootstrap
   - dstat
-  - tcpdump
-  - lsof
   - htop
+  - iotop
+  - iptables-persistent
+  - linux-crashdump
+  - lsof
+  - lvm2
+  - ntp
+  - ntpdate
+  - openssh-server
+  - sudo
+  - tcpdump
+  - vim
+  - vlan
+
+# kernel modules required on hosts
+rpc_host_kernel_modules:
+  - bonding
+  - 8021q
+
+# sysctl parameters required on hosts
+rpc_host_kernel_sysctl:
+  - { key: 'net.ipv4.ip_forward', value: 1 }
+  - { key: 'net.ipv4.conf.all.rp_filter', value: 0 }
+  - { key: 'net.ipv4.conf.default.rp_filter', value: 0 }
 
 holland_repo_package_name: holland
 holland_service_name: holland

--- a/playbooks/roles/rpc_support/tasks/host_kernel_modules.yml
+++ b/playbooks/roles/rpc_support/tasks/host_kernel_modules.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install packages required for support
-  apt:
-    pkg: "{{ item }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 600
-  with_items: support_util_packages
+- name: "Ensure kernel module(s)"
+  modprobe:
+    name: "{{ item }}"
+  with_items: rpc_host_kernel_modules
+  when: rpc_host_kernel_modules is defined
   tags:
-    - support_packages
+    - rpc-host-kernel-modules
+
+- name: "Ensure kernel module(s) loaded at boot"
+  lineinfile:
+    dest: /etc/modules
+    line: "{{ item }}"
+  with_items: rpc_host_kernel_modules
+  when: rpc_host_kernel_modules is defined
+  tags:
+    - rpc-host-kernel-modules

--- a/playbooks/roles/rpc_support/tasks/host_kernel_tuning.yml
+++ b/playbooks/roles/rpc_support/tasks/host_kernel_tuning.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2014, Rackspace US, Inc.
+# Copyright 2015, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install packages required for support
-  apt:
-    pkg: "{{ item }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 600
-  with_items: support_util_packages
-  tags:
-    - support_packages
+- name: Host kernel sysctl tuning
+  sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    sysctl_set: "{{ item.set|default('yes') }}"
+    state: "{{ item.state|default('present') }}"
+    reload: "{{ item.reload|default('yes') }}"
+  ignore_errors: true
+  with_items: rpc_host_kernel_sysctl
+  when: rpc_host_kernel_sysctl is defined

--- a/playbooks/roles/rpc_support/tasks/main.yml
+++ b/playbooks/roles/rpc_support/tasks/main.yml
@@ -15,6 +15,14 @@
 
 - include: rpc_release.yml
 
+- include: host_kernel_modules.yml
+  when: >
+    inventory_hostname in groups['hosts']
+
+- include: host_kernel_tuning.yml
+  when: >
+    inventory_hostname in groups['hosts']
+
 - include: support_preinstall.yml
 
 - include: bashrc.yml


### PR DESCRIPTION
This patch adds several packages requested by RPC support to all hosts and
containers, adds kernel module loading and sysctl tuning to all hosts.

The reference for all additions can be found in the description and comments
for https://bugs.launchpad.net/openstack-ansible/+bug/1400424