### PR TITLE
Adjust group name for nova_console group

### DIFF
--- a/playbooks/roles/rpc_support/tasks/main.yml
+++ b/playbooks/roles/rpc_support/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - include: spice_console.yml
   when: >
-    inventory_hostname in groups['nova_spice_console']
+    inventory_hostname in groups['nova_console']
   tags:
     - nova_spice_console
 


### PR DESCRIPTION
The nova_spice_console group has changed to be called "nova_console"
this change adjusted the reference in the play so that the spice console
tasks can be run successfully.

Fixes-Issues: #86