### PR TITLE
Rename nova_spice_console to nova_console

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -144,11 +144,11 @@ POOL_PARTS = {
         'group': 'nova_api_os_compute',
         'hosts': []
     },
-    'nova_spice_console': {
+    'nova_console': {
         'port': 6082,
         'backend_port': 6082,
         'mon_type': 'http',
-        'group': 'nova_spice_console',
+        'group': 'nova_console',
         'hosts': []
     },
     'cinder_api': {


### PR DESCRIPTION
In Kilo, we renamed the nova_spice_console group to nova_console. This change keeps our f5 config consistent with that code base.