### PR TITLE
Adding warning and critical thresholds for fileystem checks

### DIFF
--- a/etc/openstack_deploy/user_extras_variables.yml
+++ b/etc/openstack_deploy/user_extras_variables.yml
@@ -67,14 +67,17 @@ maas_alarm_remote_consecutive_count: 1
 # maas_excluded_devices: ['xvde']
 
 # Set the threshold for filesystem monitoring when you are not specifying specific filesystems.
-maas_filesystem_threshold: 90.0
+maas_filesystem_warning_threshold: 90.0
+maas_filesystem_critical_threshold: 90.0
 # Explicitly set the filesystems to set up monitors/alerts for.
 # NB You can override these in rpc_user_config per device using "maas_filesystem_overrides"
 # maas_filesystem_monitors:
 #  - filesystem: /
-#    threshold: 90.0
+#    warning_threshold: 80.0
+#    critical_threshold: 90.0
 #  - filesystem: /boot
-#    threshold: 90.0
+#    warning_threshold: 80.0
+#    critical_threshold: 90.0
 
 # For an AIO it's recommended to set the following to limit the expected RAM
 # usage of elasticsearch.

--- a/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/playbooks/roles/rpc_maas/defaults/main.yml
@@ -208,7 +208,8 @@ maas_fqdn_extension:
 # maas_filesystem_threshold: Sets the threshold (%) for filesystem monitoring when you are not
 #                            specifying specific filesystems.
 #
-maas_filesystem_threshold: 90.0
+maas_filesystem_warning_threshold: 80.0
+maas_filesystem_critical_threshold: 90.0
 
 #
 # maas_filesystem_monitors: Explicitly set the filesystems to set up monitors/alerts for.
@@ -218,9 +219,11 @@ maas_filesystem_threshold: 90.0
 #
 # maas_filesystem_monitors:
 #  - filesystem: /
-#    threshold: 90.0
+#    warning_threshold: 80.0
+#    critical_threshold: 90.0
 #  - filesystem: /boot
-#    threshold: 90.0
+#    warning_threshold: 80.0
+#    critical_threshold: 90.0
 
 raxmon_repo_url: "http://stable.packages.cloudmonitoring.rackspace.com/ubuntu-14.04-x86_64"
 maas_apt_keys:

--- a/playbooks/roles/rpc_maas/tasks/cdm.yml
+++ b/playbooks/roles/rpc_maas/tasks/cdm.yml
@@ -48,7 +48,8 @@
     check_timeout: "{{ maas_check_timeout }}"
     agent_type: "agent.filesystem"
     drives: "{{ mounted_drives.split(',') }}"
-    threshold: "{{ maas_filesystem_threshold }}"
+    warning_threshold: "{{ maas_filesystem_warning_threshold }}"
+    critical_threshold: "{{ maas_filesystem_critical_threshold }}"
   user: root
   when: >
     maas_filesystem_overrides is not defined and maas_filesystem_monitors is not defined

--- a/playbooks/roles/rpc_maas/tasks/filesystem_autosetup.yml
+++ b/playbooks/roles/rpc_maas/tasks/filesystem_autosetup.yml
@@ -40,7 +40,7 @@
   with_items: check_exists.results
 
 - name: Create alarm if it does not exist
-  shell: raxmon-alarms-create --entity-id {{ entity_id.stdout|quote }} --check-id {{ item[1].stdout|quote }} --notification-plan {{ maas_notification_plan }} --label "Disk space used on {{ item[1].item.item|quote }}--{{ inventory_hostname|quote }}" --criteria ":set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric['used'], metric['total']) >= {{ threshold }}) { return new AlarmStatus(WARNING, '{{ item[1].item.item }} filesystem is >= {{ threshold }}% full.'); }"
+  shell: raxmon-alarms-create --entity-id {{ entity_id.stdout|quote }} --check-id {{ item[1].stdout|quote }} --notification-plan {{ maas_notification_plan }} --label "Disk space used on {{ item[1].item.item|quote }}--{{ inventory_hostname|quote }}" --criteria ":set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric['used'], metric['total']) >= {{ critical_threshold }}) { return new AlarmStatus(CRITICAL, '{{ item[1].item.item }} filesystem is >= {{ critical_threshold }}% full.'); } if (percentage(metric['used'], metric['total']) >= {{ warning_threshold }}) { return new AlarmStatus(WARNING, '{{ item[1].item.item }} filesystem is >= {{ warning_threshold }}% full.'); }"
   when: item[0].rc != 0 and item[0].item.item == item[1].item.item
   with_nested:
     - alarm_exists.results

--- a/playbooks/roles/rpc_maas/tasks/filesystem_setup.yml
+++ b/playbooks/roles/rpc_maas/tasks/filesystem_setup.yml
@@ -40,7 +40,7 @@
   with_items: check_exists.results
 
 - name: Create alarm if it does not exist
-  shell: raxmon-alarms-create --entity-id {{ entity_id.stdout|quote }} --check-id {{ item[1].stdout|quote }} --notification-plan {{ maas_notification_plan }} --label "Disk space used on {{ item[1].item.item.filesystem|quote }}--{{ inventory_hostname|quote }}" --criteria ":set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric['used'], metric['total']) >= {{ item[1].item.item.threshold }}) { return new AlarmStatus(WARNING, '{{ item[1].item.item.filesystem }} filesystem is >= {{ item[1].item.item.threshold }}% full.'); }"
+  shell: raxmon-alarms-create --entity-id {{ entity_id.stdout|quote }} --check-id {{ item[1].stdout|quote }} --notification-plan {{ maas_notification_plan }} --label "Disk space used on {{ item[1].item.item.filesystem|quote }}--{{ inventory_hostname|quote }}" --criteria ":set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (percentage(metric['used'], metric['total']) >= {{ critical_threshold }}) { return new AlarmStatus(CRITICAL, '{{ item[1].item.item }} filesystem is >= {{ critical_threshold }}% full.'); } if (percentage(metric['used'], metric['total']) >= {{ warning_threshold }}) { return new AlarmStatus(WARNING, '{{ item[1].item.item }} filesystem is >= {{ warning_threshold }}% full.'); }"
   when: item[0].rc != 0 and item[0].item.item.filesystem == item[1].item.item.filesystem
   with_nested:
     - alarm_exists.results


### PR DESCRIPTION
Currently we do only create warning alarms which do not trigger core.
I added configurable warning and critical thresholds. Critical thresholds will also set off core.
Additionally we are working in getting warnings into core as well for our devices