### PR TITLE
Add apt-pinning variable file.

### DIFF
--- a/rpcd/etc/openstack_deploy/user_apt_packages.yml
+++ b/rpcd/etc/openstack_deploy/user_apt_packages.yml
@@ -1,0 +1,11 @@
+# This file will contain any apt packages that the deployer would like to pin to a particular version.
+# 
+# This relies on the apt_package_pinning role from os-ansible-deployment.
+#
+# Pinning happens in the 'apt_pinned_packages' variable.
+#
+# apt_pinned_packages: 
+#   - { package: "lxc", version: "1.0.7-0ubuntu0.1" }
+#   - { package: "libvirt-bin", version: "1.2.2-0ubuntu13.1.9" }
+#   - { package: "rabbitmq-server", origin: "www.rabbitmq.com" }
+#   - { package: "*", release: "MariaDB" } 


### PR DESCRIPTION
This file is separated from the user_extras_variables.yml file in order
to make it more clear to administrators that there are pinned packages.

Also, this is being included with the packages commented out until we
confirm which ones rpc-extras would like to pin.