### PR TITLE
Add alarm for rabbitmq_max_channels_per_conn

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/local.yml
@@ -310,6 +310,7 @@
     alarms:
       - { 'name': 'rabbitmq_disk_free_alarm_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["rabbitmq_disk_free_alarm_status"] != 1) { return new AlarmStatus(CRITICAL, "rabbitmq_disk_free_alarm_status triggered"); }' }
       - { 'name': 'rabbitmq_mem_alarm_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["rabbitmq_mem_alarm_status"] != 1) { return new AlarmStatus(CRITICAL, "rabbitmq_mem_alarm_status triggered"); }' }
+      - { 'name': 'rabbitmq_max_channels_per_conn', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["rabbitmq_max_channels_per_conn"] > 10) { return new AlarmStatus(CRITICAL, "Detected RabbitMQ connections with > 10 channels, check RabbitMQ and all Openstack consumers"); }' }
   user: root
   when: >
     inventory_hostname in groups['rabbitmq']


### PR DESCRIPTION
This commit adds a new alarm for metric rabbitmq_max_channels_per_conn,
which is a metric representing the largest (max) number of channels per
connection across all rabbitmq connections.  We have chosen a threshold
of 10 -- running a dev cluster periodically sees
rabbitmq_max_channels_per_conn > 1 and 10 is an 'arbitrary but likely
reasonable limit' which we can use to prevent channel ballooning.

Closes issue #109

(cherry picked from commit 2ccf7974c7c7d7682f6dd465a3541f2b79a16ee8)