### PR TITLE
Adjust nova_spice_console group to nova_console

### DIFF
--- a/rpcd/playbooks/roles/rpc_support/tasks/main.yml
+++ b/rpcd/playbooks/roles/rpc_support/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - include: spice_console.yml
   when: >
-    inventory_hostname in groups['nova_spice_console']
+    inventory_hostname in groups['nova_console']
   tags:
     - nova_spice_console
 

--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -144,11 +144,11 @@ POOL_PARTS = {
         'group': 'nova_api_os_compute',
         'hosts': []
     },
-    'nova_spice_console': {
+    'nova_console': {
         'port': 6082,
         'backend_port': 6082,
         'mon_type': 'http',
-        'group': 'nova_spice_console',
+        'group': 'nova_console',
         'hosts': []
     },
     'cinder_api': {


### PR DESCRIPTION
nova_spice_console group was renamed to nova_console, the f5-config
generator needed to be updated to work properly with the new
nova_console. Additionally the nova_spice_console tasks were renamed,
and targeted appropriately against the nova_console group.

For consistency, adjusted the name on the nova_spice_console maas check
to be "nova_console_check".

Fixes-Issue: #136