### PR TITLE
Add 10.x to 11.x upgrade scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ above.
   1. edit `/etc/openstack_deploy/user_extras_variables.yml` to add credentials
   2. run the MaaS setup plays:
      `cd /opt/rpc-extras/rpcd/playbooks && openstack-ansible setup-maas.yml`
+
+# Upgrading
+
+To run an upgrade of an existing os-ansible-deployment installation:
+
+1. Run`scripts/upgrade.sh`.
+
+Please note the following behaviors that are **destructive**:
+    * `/etc/rpc_deploy` will be deprecated and the file structure moved to 
+      `/etc/openstack_deploy`.

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# (c) 2015, Nolan Brubaker <nolan.brubaker@rackspace.com>
+set -eux pipefail
+
+OSAD_DIR='/opt/rpc-extras/os-ansible-deployment'
+RPCD_DIR='/opt/rpc-extras/rpcd'
+
+# Do the actual upgrade
+cd /opt/rpc-extras/os-ansible-deployment
+/opt/rpc-extras/os-ansible-deployment/scripts/run-upgrade.sh
+
+# install RPC-specific stuff
+source /opt/rpc-extras/os-ansible-deployment/scripts/scripts-library.sh
+cd "${RPCD_DIR}"/playbooks/
+
+# TODO(nolan) need to remove the stuff in the maas directory. Maybe make a
+# play for upgrade-maas?
+
+install_bits site.yml


### PR DESCRIPTION
These scripts will allow for upgrading an existing 10.x RPC installation
to an 11.x-based one.

This is a squashed version of #131, with some changes from that PR integrated. I did this in order to get the process going without having to wake up @stevelle, not intending to snipe.