### PR TITLE
Maintain maas pip requirements in role

### DIFF
--- a/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
+++ b/rpcd/playbooks/roles/rpc_maas/defaults/main.yml
@@ -233,9 +233,8 @@ maas_apt_packages:
   - rackspace-monitoring-agent
   - mariadb-client
 
-maas_pip_requirements_file: "/usr/lib/rackspace-monitoring-agent/plugins/requirements.txt"
-
-maas_pip_dependencies:
+maas_pip_packages:
   - rackspace-monitoring-cli
+  - ipaddr
 
 maas_plugin_dir: /opt/rpc-extras/maas/

--- a/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/package_install.yml
@@ -21,9 +21,8 @@
     cache_valid_time: 600
   with_items: maas_apt_packages
 
-- name: Install monitoring-cli pip package
+- name: Install pip packages
   pip:
     name: "{{ item }}"
     state: present
-    extra_args: "--isolated"
-  with_items: maas_pip_dependencies
+  with_items: maas_pip_packages

--- a/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
+++ b/rpcd/playbooks/roles/rpc_maas/tasks/raxmon_agent_install.yml
@@ -38,10 +38,6 @@
     group: "root"
     mode: "0600"
 
-- name: Install python dependencies
-  pip:
-    requirements: "{{ maas_pip_requirements_file }}"
-
 - name: Entity {{ entity_name }} count
   shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"
   register: entity_count


### PR DESCRIPTION
Currently, we maintain maas pip requirements in maas/requirement.txt.
The problem here is that repo-builder cannot properly build these
requirements and as such we have to move the dependency list into the
role itself.

Closes issue #144

(cherry picked from commit e2e7f7ea145bde4dfe14dd099de95004ad12d3aa)